### PR TITLE
fix(ci): updated upload-artifact action version, provided missing args for download-artifact

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,1 +1,2 @@
+[run]
 relative_files = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,1 @@
+relative_files = true

--- a/.github/workflows/pr_sonar_and_coverage_reports.yaml
+++ b/.github/workflows/pr_sonar_and_coverage_reports.yaml
@@ -13,7 +13,7 @@ permissions:
   actions: read
 
 jobs:
-  publish-reports:
+  sonarqube-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -29,14 +29,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Publish coverage report
-        uses: orgoro/coverage@v3.2
-        with:
-          coverageFile: coverage.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          thresholdAll: 0.8
-
       - name: Run SonarQube analysis
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  publish-coverage-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+

--- a/.github/workflows/pr_sonar_and_coverage_reports.yaml
+++ b/.github/workflows/pr_sonar_and_coverage_reports.yaml
@@ -10,6 +10,7 @@ permissions:
   pull-requests: write
   checks: write
   statuses: write
+  actions: read
 
 jobs:
   publish-reports:
@@ -23,6 +24,8 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: pytest-artifacts
+          repository: ${{ github.repository }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Publish coverage report

--- a/.github/workflows/pr_sonar_and_coverage_reports.yaml
+++ b/.github/workflows/pr_sonar_and_coverage_reports.yaml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           name: pytest-artifacts
           repository: ${{ github.repository }}

--- a/.github/workflows/pr_sonar_and_coverage_reports.yaml
+++ b/.github/workflows/pr_sonar_and_coverage_reports.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -108,6 +108,7 @@ jobs:
         with:
           name: pytest-artifacts
           path: |
+            .coverage
             report.xml
             coverage.xml
             tests/sdk/fuzzed

--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -2,6 +2,9 @@ name: Workflow Push and Pull Request
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -103,6 +103,19 @@ jobs:
           poetry run coverage xml
           poetry run coverage report
 
+      - name: Coverage comment
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Store Pull Request comment to be posted
+        uses: actions/upload-artifact@v6
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt
+
       - name: Archive artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v6
-        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        if: steps.coverage_comment.outputs.comment_file_written == 'true'
         with:
           name: python-coverage-comment-action
           path: python-coverage-comment-action.txt


### PR DESCRIPTION
After the configuration of "PR SonarQube and Coverage reports" workflow - there turned out to be missing configuration for download-artifact action and it's version is outdated.