### PR TITLE
fix(ci): make coverage comment run only on PRs

### DIFF
--- a/.github/workflows/pr_sonar_and_coverage_reports.yaml
+++ b/.github/workflows/pr_sonar_and_coverage_reports.yaml
@@ -33,6 +33,13 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.python.coverage.reportPaths=coverage.xml
 
   publish-coverage-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -108,6 +108,7 @@ jobs:
 
       - name: Coverage comment
         id: coverage_comment
+        if: github.event_name == 'pull_request'
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR is to prevent coverage comments from running on protected branches and manually provide the PR context for the SonarQube.