### PR TITLE
fix(model / ecu): MII literal in lowercase as all other phy types

### DIFF
--- a/src/flync/model/flync_4_ecu/phy.py
+++ b/src/flync/model/flync_4_ecu/phy.py
@@ -107,7 +107,7 @@ class MII(FLYNCBaseModel):
         Operating mode, either MAC or PHY.
     """
 
-    type: Literal["MII"] = Field(default="MII")
+    type: Literal["mii"] = Field(default="mii")
     speed: Optional[Literal[10, 100]] = Field(default=100)
     mode: Literal["mac", "phy"] = Field()
 

--- a/tests/model/conftest.py
+++ b/tests/model/conftest.py
@@ -172,7 +172,7 @@ def integrity_with_confidentiality_entry():
 
 @pytest.fixture
 def MII_entry():
-    MII_entry = MII(type="MII", speed=100, mode="mac")
+    MII_entry = MII(type="mii", speed=100, mode="mac")
     yield MII_entry
 
 

--- a/tests/model/tests_4_ecu/phy/test_mii_config.py
+++ b/tests/model/tests_4_ecu/phy/test_mii_config.py
@@ -8,8 +8,8 @@ from flync.model.flync_4_ecu.port import ECUPort
 
 
 def test_positive_mii_config_ecu_port():
-    mii_config1 = {"type": "MII", "mode": "mac", "speed": 100}
-    mii_config2 = {"type": "MII", "mode": "phy", "speed": 100}
+    mii_config1 = {"type": "mii", "mode": "mac", "speed": 100}
+    mii_config2 = {"type": "mii", "mode": "phy", "speed": 100}
 
     ecu_port1 = ECUPort.model_validate(
         {
@@ -128,8 +128,8 @@ def test_positive_xfi_config_ecu_port(virtual_controller_interface):
 
 
 def test_negative_speed_for_mii_ecu_port():
-    mii_config1 = {"type": "MII", "mode": "mac", "speed": 1000}
-    mii_config2 = {"type": "MII", "mode": "phy", "speed": 1000}
+    mii_config1 = {"type": "mii", "mode": "mac", "speed": 1000}
+    mii_config2 = {"type": "mii", "mode": "phy", "speed": 1000}
 
     with pytest.raises(ValidationError) as val_error_port1:
         ecu_port1 = ECUPort.model_validate(
@@ -246,8 +246,8 @@ def test_negative_speed_for_xfi_ecu_port():
 
 
 def test_positive_mii_config_switch_port():
-    mii_config1 = {"type": "MII", "mode": "mac", "speed": 100}
-    mii_config2 = {"type": "MII", "mode": "phy", "speed": 100}
+    mii_config1 = {"type": "mii", "mode": "mac", "speed": 100}
+    mii_config2 = {"type": "mii", "mode": "phy", "speed": 100}
 
     switch_port1 = SwitchPort.model_validate(
         {


### PR DESCRIPTION
phy type casing is not consistent in the model, quick fix to align MII type to lowercasing "mii"