### PR TITLE
fix(sdk): loader handles relative paths 

### DIFF
--- a/src/flync/sdk/helpers/validate_workspace.py
+++ b/src/flync/sdk/helpers/validate_workspace.py
@@ -90,10 +90,6 @@ args = parser.parse_args()
 path = Path(args.path)
 flync_name = args.name
 
-if not path.is_absolute():
-    print("Error: Path must be absolute.", file=sys.stderr)
-    sys.exit(1)
-
 if not path.exists():
     print(f"Error: Path does not exist: {path}", file=sys.stderr)
     sys.exit(1)

--- a/src/flync/sdk/workspace/flync_workspace.py
+++ b/src/flync/sdk/workspace/flync_workspace.py
@@ -464,6 +464,7 @@ class FLYNCWorkspace:
             current_type = FLYNCModel
         if isinstance(path, str):
             path = Path(path)
+        path = path.absolute()
         module_load_info: dict = {}
         # start by loading each field
         for field_name, field_info in current_type.model_fields.items():

--- a/tests/sdk/conftest.py
+++ b/tests/sdk/conftest.py
@@ -1,7 +1,12 @@
 import pytest
 
 
+
 @pytest.fixture
 def get_flync_example_path(pytestconfig):
     project_root = pytestconfig.rootpath
     return str((project_root / "examples" / "flync_example"))
+
+@pytest.fixture
+def get_relative_flync_example_path():
+    return "examples/flync_example"

--- a/tests/sdk/test_helpers.py
+++ b/tests/sdk/test_helpers.py
@@ -23,6 +23,23 @@ def test_load_workspace_from_flync_object(get_flync_example_path):
     assert loaded_ws.flync_model.metadata
     assert model_has_socket(loaded_ws)
 
+def test_load_workspace_from_flync_object_relative_path(get_relative_flync_example_path):
+    workspace_name_object = "flync_workspace_from_folder"
+    loaded_ws = FLYNCWorkspace.load_workspace(
+        workspace_name_object, get_relative_flync_example_path
+    )
+    assert loaded_ws is not None
+    # To be improved.
+    assert loaded_ws.flync_model is not None
+    assert loaded_ws.flync_model.ecus
+    assert loaded_ws.flync_model.topology
+    assert loaded_ws.flync_model.topology.system_topology
+    assert loaded_ws.flync_model.general
+    assert loaded_ws.flync_model.general.someip_config
+    assert loaded_ws.flync_model.general.tcp_profiles
+    assert loaded_ws.flync_model.metadata
+    assert model_has_socket(loaded_ws)
+
 
 def test_roundtrip_conversion(get_flync_example_path):
     workspace_name_object = "flync_workspace_from_folder"


### PR DESCRIPTION
The loader is only able to handle absolute paths to a config right now, and throws and error in that case.
This PR fixes the issue and converts relative path to absolutes in the workspace loader.