### PR TITLE
fix(ci): support SonarQube for external PRs, prevent coverage comment from running on main

### DIFF
--- a/.github/workflows/pr_sonar_and_coverage_reports.yaml
+++ b/.github/workflows/pr_sonar_and_coverage_reports.yaml
@@ -43,6 +43,7 @@ jobs:
 
   publish-coverage-comment:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Post comment
         uses: py-cov-action/python-coverage-comment-action@v3

--- a/.github/workflows/pr_sonar_and_coverage_reports.yaml
+++ b/.github/workflows/pr_sonar_and_coverage_reports.yaml
@@ -13,7 +13,69 @@ permissions:
   actions: read
 
 jobs:
-  sonarqube-check:
+  sonarqube-check-pr:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: pytest-artifacts
+          repository: ${{ github.repository }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Install Linux dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Resolve PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          pr_json=$(gh api -H "Accept: application/vnd.github+json" "/repos/$REPO/commits/$SHA/pulls")
+
+          pr_number=$(echo "$pr_json" | jq -r '.[0].number // empty')
+          head_ref=$(echo "$pr_json" | jq -r '.[0].head.ref // empty')
+          base_ref=$(echo "$pr_json" | jq -r '.[0].base.ref // empty')
+
+          if [ -z "$pr_number" ] || [ -z "$head_ref" ] || [ -z "$base_ref" ]; then
+            echo "Could not resolve PR for SHA=$SHA" >&2
+            echo "$pr_json" >&2
+            exit 1
+          fi
+
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch PRs base branch
+        run: |
+          git fetch --no-tags --prune origin \
+            ${{ steps.pr.outputs.base_ref }}:refs/remotes/origin/${{ steps.pr.outputs.base_ref }}
+
+      - name: Run SonarQube analysis
+        uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ steps.pr.outputs.number }}
+            -Dsonar.pullrequest.branch=${{ steps.pr.outputs.head_ref }}
+            -Dsonar.pullrequest.base=${{ steps.pr.outputs.base_ref }}
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+
+  sonarqube-check-main:
+    if: github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -36,9 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: >
-            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
-            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.branch.name=main
             -Dsonar.python.coverage.reportPaths=coverage.xml
 
   publish-coverage-comment:


### PR DESCRIPTION
Currently SonarQube does not retrieve PRs metadata when it's being run from external PR. This PR is aimed to fix this issue and in addition prevent python coverage comment from trying to post when the workflow is being executed on main branch.