### PR TITLE
chore: pypi compliant pyproject release and PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!-- MAKE SURE TO REMOVE ANY SECTIONS/PARTS/CHECKPOINTS THAT ARE NOT RELEVANT TO YOUR PR -->
+
+## Description
+
+<!-- Describe the changes made in this pull request. Explain why these changes are being introduced and include relevant context if needed. -->
+
+## Related Issues/PRs
+
+<!-- Link any related issues using references -->
+
+## Changes Made
+
+<!-- List out the main changes in this PR. Use bullet points for clarity. -->
+
+-
+
+## Screenshots or Logs or Previews (if applicable)
+
+<!-- Add screenshots or log snippets to show the before and after, or to help explain the change. -->
+
+-
+
+## Testing Instructions (if applicable)
+
+<!-- Provide clear testing instructions of your changes for reviewers. -->
+
+1.
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines.
+- [ ] I have added tests to cover these changes (if applicable).
+- [ ] All new and existing tests pass.
+- [ ] I have updated the documentation (if applicable).
+- [ ] I have verified these changes **both** locally on my development environment as well as in production/CI environments and checked that there are no errors (if applicable).
+- [ ] This pull request is ready for review.
+
+## Notes for Reviewers
+
+<!-- Add any additional notes or things to consider for reviewers. -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flync"
-version = "0.9.1"
+version = "0.0.0"
 packages = [
     { include = "flync", from = "src" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flync"
-version = "0.9.0"
+version = "0.9.1"
 packages = [
     { include = "flync", from = "src" }
 ]
@@ -10,15 +10,18 @@ authors = [
     "Dr. Lars Völker <lars.voelker@technica-engineering.de>"
 ]
 readme = "README.md"
-license = "Apache 2.0"
+license = "Apache-2.0"
 homepage = "https://flync-language.com"
 repository = "https://github.com/Technica-Engineering/FLYNC"
 documentation = "https://github.com/Technica-Engineering/FLYNC"
 keywords = ["automotive", "network", "someip", "topology", "flync"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Operating System :: OS Independent",
-    "License :: OSI Approved :: Apache 2.0 License"
+    "Operating System :: OS Independent"
+]
+[project]
+license-files = [
+    "LICENSE"
 ]
 
 [tool.poetry.dependencies]
@@ -84,6 +87,8 @@ testpaths = ["tests"]
 enable = true
 vcs = "git"
 style = "semver"
+pattern = '(?P<base>\d+\.\d+\.\d+)'
+pattern-prefix = "release-"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
The changes in pyproject.toml are needed to create releases that can be uploaded to PYPI website