### PR TITLE
fix: configured ruamel.yaml to preserve quotes and to use round-trip mode

### DIFF
--- a/src/flync/sdk/workspace/document.py
+++ b/src/flync/sdk/workspace/document.py
@@ -4,7 +4,8 @@ from ruamel.yaml import YAML
 
 from flync.sdk.utils.sdk_types import PathType
 
-yaml = YAML()
+yaml = YAML(typ="rt")
+yaml.preserve_quotes = True
 
 
 class Document:


### PR DESCRIPTION
## Description

Update loading of ruamel.yaml.YAML to use round-trip mode to utilize full YAML AST and to preserve quotes style not to normalize it on dump.

## Changes Made

<!-- List out the main changes in this PR. Use bullet points for clarity. -->

- Updated sdk/workspace/document.py

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have verified these changes **both** locally on my development environment as well as in production/CI environments and checked that there are no errors (if applicable).
- [x] This pull request is ready for review.