### PR TITLE
hotfix: handle errors properly when file base is container and not model

### DIFF
--- a/src/flync/core/utils/exceptions_handling.py
+++ b/src/flync/core/utils/exceptions_handling.py
@@ -99,7 +99,9 @@ def safe_yaml_position(  # noqa # nosonar
             if origin in (list, tuple) and isinstance(part, int):
                 current_model = args[0] if args else None
             elif origin is dict and not isinstance(part, int):
-                current_model = args[1] if len(args) > 1 else None  # type: ignore[misc]
+                current_model = (
+                    args[1] if len(args) > 1 else None
+                )  # noqa # type: ignore[misc]
             elif origin is None:
                 current_model = annotation
             else:

--- a/src/flync/core/utils/exceptions_handling.py
+++ b/src/flync/core/utils/exceptions_handling.py
@@ -79,20 +79,32 @@ def safe_yaml_position(  # noqa # nosonar
                 return _fallback_position(parent)
 
             # Descend model if available
-            if current_model:
+            if not current_model:
+                continue
+
+            if hasattr(current_model, "model_fields"):
                 field = current_model.model_fields.get(part)
-                if field:
-                    annotation = field.annotation
-                    # For List[Model], extract inner type
-                    origin = getattr(annotation, "__origin__", None)
-                    if origin in (list, tuple):
-                        current_model = getattr(
-                            annotation, "__args__", [None]
-                        )[0]
-                    else:
-                        current_model = annotation
-                else:
-                    current_model = None
+                annotation = field.annotation if field else None
+            else:
+                # current_model is already a container generic (e.g. dict[str, Model])
+                annotation = current_model
+
+            if annotation is None:
+                current_model = None
+                continue
+
+            origin = getattr(annotation, "__origin__", None)
+            args = getattr(annotation, "__args__", None) or ()
+            if origin in (list, tuple) and isinstance(part, int):
+                current_model = args[0] if args else None
+            elif origin is dict and not isinstance(part, int):
+                current_model = args[1] if len(args) > 1 else None
+            elif origin is None:
+                current_model = annotation
+            else:
+                current_model = None
+            if not hasattr(current_model, "model_fields"):
+                current_model = None
 
     # Get line/column for final key or index
     return _extract_position(parent, last_key)

--- a/src/flync/core/utils/exceptions_handling.py
+++ b/src/flync/core/utils/exceptions_handling.py
@@ -86,7 +86,8 @@ def safe_yaml_position(  # noqa # nosonar
                 field = current_model.model_fields.get(part)
                 annotation = field.annotation if field else None
             else:
-                # current_model is already a container generic (e.g. dict[str, Model])
+                # current_model is already a container generic
+                # (e.g. dict[str, Model])
                 annotation = current_model
 
             if annotation is None:
@@ -98,7 +99,7 @@ def safe_yaml_position(  # noqa # nosonar
             if origin in (list, tuple) and isinstance(part, int):
                 current_model = args[0] if args else None
             elif origin is dict and not isinstance(part, int):
-                current_model = args[1] if len(args) > 1 else None
+                current_model = args[1] if len(args) > 1 else None  # type: ignore[misc]
             elif origin is None:
                 current_model = annotation
             else:

--- a/src/flync/model/flync_4_someip/someip_datatypes.py
+++ b/src/flync/model/flync_4_someip/someip_datatypes.py
@@ -1,13 +1,7 @@
 """defines the base class each datatype shares"""
 
-from typing import (
-    Annotated,
-    ClassVar,
-    List,
-    Literal,
-    Optional,
-    Union as TypingUnion,
-)
+from typing import Annotated, ClassVar, List, Literal, Optional
+from typing import Union as TypingUnion
 
 from pydantic import (
     BaseModel,

--- a/src/flync/model/flync_4_someip/someip_datatypes.py
+++ b/src/flync/model/flync_4_someip/someip_datatypes.py
@@ -6,7 +6,7 @@ from typing import (
     List,
     Literal,
     Optional,
-    Union,
+    Union as TypingUnion,
 )
 
 from pydantic import (
@@ -585,7 +585,7 @@ class Enum(Datatype):
 
     name: str = Field(default="Enum")
     type: Literal["enum"] = Field("enum")
-    base_type: Union["Ints"] = Field(
+    base_type: TypingUnion["Ints"] = Field(
         default_factory=lambda: Enum.default_base_type()
     )
     entries: List[EnumEntry] = Field(default_factory=list)
@@ -625,7 +625,7 @@ class Enum(Datatype):
 
     @staticmethod
     def default_base_type() -> UInt8:
-        return UInt8(type="uint8", endianness="LE", signed=False, bit_size=8)
+        return UInt8(type="uint8", endianness="BE", signed=False, bit_size=8)
 
 
 class BaseString(Datatype):


### PR DESCRIPTION
## Description

Some yaml files represent a container over a pydantic files rather than the model directly. (example dict[str, ECUPort]
The error detection feature that tries to map errors to their location didn't account for this and broke the loader when the yaml file is invalid without giving proper error outpu;

## Related Issues/PRs

caused by !58

## Changes Made

when mapping between errors and their location, check to see if it's a container of a model and not only a model.

## Testing Instructions (if applicable)

1. in current main, "break" the ecu ports yaml file
2. loader will return a broken workspace

## Checklist

- [x] My code follows the project's style guidelines.
- [ ] I have added tests to cover these changes (if applicable).
- [x] All new and existing tests pass.
- [x] I have updated the documentation (if applicable).
- [x] I have verified these changes **both** locally on my development environment as well as in production/CI environments and checked that there are no errors (if applicable).
- [x] This pull request is ready for review.