### PR TITLE
fix(ci): silent fail of type check job

### DIFF
--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -78,7 +78,9 @@ jobs:
           mkdir type-check-reports
 
       - name: Run mypy
-        run: poetry run mypy src --show-error-codes --pretty --install-types --non-interactive | tee type-check-reports/mypy-report.txt
+        run: |
+          set -o pipefail
+          poetry run mypy src --show-error-codes --pretty --install-types --non-interactive | tee type-check-reports/mypy-report.txt
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Description

Currently `type-check` job is failing silently and the pipeline succeeds even when this job fails. The PR aims to fix that.

## Changes Made

- .github/workflows/push_and_pr.yaml

## Testing Instructions (if applicable)

1. Run pipeline
2. Check result of type-check job

## Checklist

- [x] My code follows the project's style guidelines.
- [ ] I have verified these changes in production/CI environments and checked that there are no errors.
- [ ] This pull request is ready for review.
