### PR TITLE
chore: fix model dump with sockets

### DIFF
--- a/src/flync/core/annotations/implied.py
+++ b/src/flync/core/annotations/implied.py
@@ -1,15 +1,16 @@
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import IntFlag
 
 
-class ImpliedStrategy(IntEnum):
+class ImpliedStrategy(IntFlag):
     """
     The strategy on how an implied field will be calculated.
     """
 
-    AUTO = 0
-    FOLDER_NAME = AUTO
-    FILE_NAME = 1
+    FOLDER_NAME = 0b1
+    FILE_NAME = 0b10
+    OPTIONAL = 0b100
+    AUTO = FOLDER_NAME
 
 
 @dataclass(frozen=True)

--- a/src/flync/core/annotations/implied.py
+++ b/src/flync/core/annotations/implied.py
@@ -9,7 +9,6 @@ class ImpliedStrategy(IntFlag):
 
     FOLDER_NAME = 0b1
     FILE_NAME = 0b10
-    OPTIONAL = 0b100
     AUTO = FOLDER_NAME
 
 

--- a/src/flync/model/flync_4_ecu/ecu.py
+++ b/src/flync/model/flync_4_ecu/ecu.py
@@ -123,9 +123,9 @@ class ECU(UniqueName):
             output_structure=OutputStrategy.FOLDER,
             naming_strategy=NamingStrategy.FIELD_NAME,
         ),
-    ] = Field(default_factory=list, exclude=True)
+    ] = Field(default_factory=list)
     multicast_groups: Optional[List[MulticastGroupMembership]] = Field(
-        default_factory=list, exclude=True
+        default_factory=list
     )
 
     def model_post_init(self, context):

--- a/src/flync/model/flync_4_ecu/socket_container.py
+++ b/src/flync/model/flync_4_ecu/socket_container.py
@@ -1,7 +1,8 @@
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 from pydantic import Field
 
+from flync.core.annotations import Implied, ImpliedStrategy
 from flync.core.base_models import FLYNCBaseModel
 
 from .sockets import SocketTCP, SocketUDP
@@ -23,6 +24,12 @@ class SocketContainer(FLYNCBaseModel):
     """
 
     vlan_id: int = Field(ge=0, le=4095, default=0)
+    name: Annotated[
+        str,
+        Implied(
+            strategy=ImpliedStrategy.FILE_NAME,
+        ),
+    ] = Field()
     sockets: Optional[List[SocketTCP | SocketUDP]] = Field(
         default_factory=list
     )

--- a/src/flync/model/flync_4_ecu/sockets.py
+++ b/src/flync/model/flync_4_ecu/sockets.py
@@ -6,6 +6,7 @@ from typing import (
     Literal,
     Optional,
     Union,
+    Annotated,
 )
 
 from pydantic import (
@@ -17,6 +18,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from flync.core.annotations import Implied, ImpliedStrategy
 from pydantic.networks import IPvAnyAddress
 
 from flync.core.base_models import DictInstances, FLYNCBaseModel
@@ -44,7 +46,7 @@ class IPv4AddressEndpoint(IPv4AddressEntry):
     """
 
     sockets: Optional[List[Union["SocketTCP", "SocketUDP"]]] = Field(
-        default_factory=list
+        default_factory=list, exclude=True
     )
 
     @model_validator(mode="after")
@@ -79,7 +81,7 @@ class IPv6AddressEndpoint(IPv6AddressEntry):
     """
 
     sockets: Optional[List[Union["SocketTCP", "SocketUDP"]]] = Field(
-        default_factory=list
+        default_factory=list, exclude=True
     )
 
     @model_validator(mode="after")

--- a/src/flync/model/flync_4_ecu/sockets.py
+++ b/src/flync/model/flync_4_ecu/sockets.py
@@ -1,4 +1,13 @@
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+    Annotated,
+)
 
 from pydantic import (
     Field,
@@ -9,6 +18,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from flync.core.annotations import Implied, ImpliedStrategy
 from pydantic.networks import IPvAnyAddress
 
 from flync.core.base_models import DictInstances, FLYNCBaseModel
@@ -160,7 +170,10 @@ class Socket(FLYNCBaseModel):
         (only applicable for sockets with a multicast endpoint_type).
     """
 
-    name: str = Field()
+    name: Annotated[
+        str,
+        Implied(strategy=ImpliedStrategy.FILE_NAME | ImpliedStrategy.OPTIONAL),
+    ] = Field()
     endpoint_address: IPvAnyAddress = Field()
     port_no: int = Field()
     deployments: Optional[List[DeploymentUnion]] = Field(default_factory=list)

--- a/src/flync/model/flync_4_ecu/sockets.py
+++ b/src/flync/model/flync_4_ecu/sockets.py
@@ -11,7 +11,6 @@ from pydantic import (
 )
 from pydantic.networks import IPvAnyAddress
 
-from flync.core.annotations import Implied, ImpliedStrategy
 from flync.core.base_models import DictInstances, FLYNCBaseModel
 from flync.core.datatypes.ipaddress import IPv4AddressEntry, IPv6AddressEntry
 from flync.core.utils.exceptions import err_minor

--- a/src/flync/model/flync_4_ecu/sockets.py
+++ b/src/flync/model/flync_4_ecu/sockets.py
@@ -6,7 +6,6 @@ from typing import (
     Literal,
     Optional,
     Union,
-    Annotated,
 )
 
 from pydantic import (
@@ -18,7 +17,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from flync.core.annotations import Implied, ImpliedStrategy
 from pydantic.networks import IPvAnyAddress
 
 from flync.core.base_models import DictInstances, FLYNCBaseModel

--- a/src/flync/model/flync_4_ecu/sockets.py
+++ b/src/flync/model/flync_4_ecu/sockets.py
@@ -1,13 +1,4 @@
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Union,
-    Annotated,
-)
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
 from pydantic import (
     Field,
@@ -18,14 +9,11 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from flync.core.annotations import Implied, ImpliedStrategy
 from pydantic.networks import IPvAnyAddress
 
+from flync.core.annotations import Implied, ImpliedStrategy
 from flync.core.base_models import DictInstances, FLYNCBaseModel
-from flync.core.datatypes.ipaddress import (
-    IPv4AddressEntry,
-    IPv6AddressEntry,
-)
+from flync.core.datatypes.ipaddress import IPv4AddressEntry, IPv6AddressEntry
 from flync.core.utils.exceptions import err_minor
 from flync.model.flync_4_someip import (
     SOMEIPSDDeployment,

--- a/src/flync/model/flync_4_ecu/sockets.py
+++ b/src/flync/model/flync_4_ecu/sockets.py
@@ -170,10 +170,7 @@ class Socket(FLYNCBaseModel):
         (only applicable for sockets with a multicast endpoint_type).
     """
 
-    name: Annotated[
-        str,
-        Implied(strategy=ImpliedStrategy.FILE_NAME | ImpliedStrategy.OPTIONAL),
-    ] = Field()
+    name: str = Field()
     endpoint_address: IPvAnyAddress = Field()
     port_no: int = Field()
     deployments: Optional[List[DeploymentUnion]] = Field(default_factory=list)

--- a/src/flync/model/flync_4_ecu/sockets.py
+++ b/src/flync/model/flync_4_ecu/sockets.py
@@ -44,7 +44,7 @@ class IPv4AddressEndpoint(IPv4AddressEntry):
     """
 
     sockets: Optional[List[Union["SocketTCP", "SocketUDP"]]] = Field(
-        default_factory=list, exclude=True
+        default_factory=list
     )
 
     @model_validator(mode="after")
@@ -79,7 +79,7 @@ class IPv6AddressEndpoint(IPv6AddressEntry):
     """
 
     sockets: Optional[List[Union["SocketTCP", "SocketUDP"]]] = Field(
-        default_factory=list, exclude=True
+        default_factory=list
     )
 
     @model_validator(mode="after")

--- a/src/flync/sdk/workspace/flync_workspace.py
+++ b/src/flync/sdk/workspace/flync_workspace.py
@@ -323,9 +323,9 @@ class FLYNCWorkspace(object):
             implied: Implied | None = get_metadata(
                 field_info.metadata, Implied
             )
-            if (
-                implied is not None
-                and ImpliedStrategy.OPTIONAL not in implied.strategy
+            if implied is not None and (
+                ImpliedStrategy.FILE_NAME in implied.strategy
+                or ImpliedStrategy.FOLDER_NAME in implied.strategy
             ):
                 exclude.add(field_name)
 
@@ -883,8 +883,8 @@ class FLYNCWorkspace(object):
             )
             return None
 
-    @staticmethod
     def __handle_implied_field_load(
+        self,
         path: Path,
         module_load_info: dict,
         field_name: str,
@@ -893,6 +893,8 @@ class FLYNCWorkspace(object):
         if implied is not None:
             if ImpliedStrategy.FOLDER_NAME in implied.strategy:
                 module_load_info[field_name] = path.name
+            elif ImpliedStrategy.FILE_NAME in implied.strategy:
+                module_load_info[field_name] = self.name_form_file(path.name)
 
     def __handle_external_field_load(
         self,

--- a/src/flync/sdk/workspace/flync_workspace.py
+++ b/src/flync/sdk/workspace/flync_workspace.py
@@ -325,7 +325,7 @@ class FLYNCWorkspace(object):
             )
             if (
                 implied is not None
-                and implied.strategy == ImpliedStrategy.FOLDER_NAME
+                and ImpliedStrategy.OPTIONAL not in implied.strategy
             ):
                 exclude.add(field_name)
 
@@ -891,7 +891,7 @@ class FLYNCWorkspace(object):
         implied: Implied | None,
     ):
         if implied is not None:
-            if implied.strategy == ImpliedStrategy.FOLDER_NAME:
+            if ImpliedStrategy.FOLDER_NAME in implied.strategy:
                 module_load_info[field_name] = path.name
 
     def __handle_external_field_load(
@@ -1015,7 +1015,7 @@ class FLYNCWorkspace(object):
         """
         for field, info in type(model).model_fields.items():
             implied: Implied | None = get_metadata(info.metadata, Implied)
-            if implied and implied.strategy == ImpliedStrategy.FILE_NAME:
+            if implied and ImpliedStrategy.FILE_NAME in implied.strategy:
                 return field
 
         return None

--- a/tests/system_test/test_multicast_paths.py
+++ b/tests/system_test/test_multicast_paths.py
@@ -48,7 +48,8 @@ def test_multicast_paths_no_tx(tmpdir):
     update_yaml_content(file_to_update, "multicast_tx:", "")
     update_yaml_content(file_to_update, "- 224.0.0.1", "")
 
-    data = read_yaml(file_to_update)
+    data: dict = read_yaml(file_to_update)
+    data["name"] = "tested socket"
     SocketContainer.model_validate(data)
 
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/unit_test/sdk/helper.py
+++ b/tests/unit_test/sdk/helper.py
@@ -1,4 +1,5 @@
 import json
+import os
 from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
@@ -29,26 +30,27 @@ def flatten_yaml(data, parent_key="", sep="."):
 
 def load_yaml_folder(folder_path: Path, sep="."):
     result = {}
-    sorted_files = sorted(folder_path.rglob("*.*"), key=lambda f: f.name)
-    for yaml_file in sorted_files:
-        if yaml_file.suffix not in (".yml", ".yaml"):
-            continue
+    for dirpath, dirnames, filenames in os.walk(folder_path):
+        dirnames.sort()
+        dir_path = Path(dirpath)
+        relative_dir = dir_path.relative_to(folder_path)
+        folder_key = sep.join(relative_dir.parts)
 
-        with open(yaml_file, "r") as f:
-            data = yaml.safe_load(f)
+        for index, filename in enumerate(sorted(filenames)):
+            if Path(filename).suffix not in (".yml", ".yaml"):
+                continue
 
-        if data is None:
-            continue
+            with open(dir_path / filename, "r") as f:
+                data = yaml.safe_load(f)
 
-        flat_data = flatten_yaml(data, sep=sep)
+            if data is None:
+                continue
 
-        # Build prefix: folder.subfolder.file
-        relative_path = yaml_file.relative_to(folder_path)
-        file_key = sep.join(relative_path.with_suffix("").parts[:-1])
+            flat_data = flatten_yaml(data, sep=sep)
+            file_key = f"{folder_key}{sep}{index}"
 
-        for key, value in flat_data.items():
-            full_key = f"{file_key}{sep}{key}"
-            result[full_key] = value
+            for key, value in flat_data.items():
+                result[f"{file_key}{sep}{key}"] = value
     return result
 
 

--- a/tests/unit_test/sdk/test_helpers.py
+++ b/tests/unit_test/sdk/test_helpers.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import shutil
 from os import sep
 from pathlib import Path
 
@@ -189,10 +190,6 @@ def test_load_workspace_from_flync_object_relative_path(
     assert model_has_socket(loaded_ws.flync_model)
 
 
-@pytest.mark.skip(
-    reason="Sockets in ECU are not dumped correctly. False positive on local execution. "
-    "Generated folder is not cleaned up after test execution, making it pass on local execution but fail in CI. To be fixed."
-)
 def test_roundtrip_conversion(get_flync_example_path):
     workspace_name_object = "flync_workspace_from_folder"
     loaded_ws = FLYNCWorkspace.load_workspace(
@@ -201,6 +198,10 @@ def test_roundtrip_conversion(get_flync_example_path):
     assert loaded_ws is not None
     assert loaded_ws.flync_model is not None
     output_path = current_dir / "generated" / Path(get_flync_example_path).name
+    # clean output folder before generating
+    if output_path.exists():
+        shutil.rmtree(output_path)
+
     dump_flync_workspace(
         loaded_ws.flync_model,
         output_path,


### PR DESCRIPTION
## Description

The sockets are nameless list items.
while the loader is able to iterate the different files to create the list, the dumper is unable to do so since it's unable to figure out a name to use for dumping.
The simple solution is to add an implied name from the file name. 

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have added tests to cover these changes (if applicable).
- [x] All new and existing tests pass.
- [x] I have updated the documentation (if applicable).
- [x] I have verified these changes **both** locally on my development environment as well as in production/CI environments and checked that there are no errors (if applicable).
- [x] This pull request is ready for review.