### PR TITLE
fix(model): SOME/IP Datatype Typedef is missing from AllTypes

### DIFF
--- a/src/flync/model/flync_4_someip/someip_datatypes.py
+++ b/src/flync/model/flync_4_someip/someip_datatypes.py
@@ -1026,6 +1026,7 @@ AllTypes = Annotated[
     | Enum
     | Boolean
     | Struct
+    | Typedef
     | Union
     | ArrayType
     | DynamicLengthString


### PR DESCRIPTION
Bugfix