### PR TITLE
fix(model): SOME/IP Datatype Typedef is missing from AllTypes

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -21,3 +21,4 @@ Bugfixes
 
 - Model: SOME/IP Datatypes follow specification more closely
 - Model: bind sockets by vlan id instead of virtual controller interface name
+- Model: Typedef was missing in AllTypes

--- a/src/flync/model/flync_4_someip/someip_datatypes.py
+++ b/src/flync/model/flync_4_someip/someip_datatypes.py
@@ -1026,6 +1026,7 @@ AllTypes = Annotated[
     | Enum
     | Boolean
     | Struct
+    | Typedef
     | Union
     | ArrayType
     | DynamicLengthString


### PR DESCRIPTION
bugfix. cherry-pick.