### PR TITLE
chore: Running PR and Push pipeline only for main and release

### DIFF
--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -1,6 +1,14 @@
 name: Workflow Push and Pull Request
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+    - release-*
+  pull_request:
+    branches:
+    - main
+    - release-*
 
 permissions:
   contents: read


### PR DESCRIPTION
Limiting the PR and Push pipeline to main and release branches.