### PR TITLE
fix(toctree): remove release note pages from docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -117,5 +117,4 @@ Resources
    flync_reference
    flync_example
    license
-   release_notes
    contact


### PR DESCRIPTION
## Description

Remove Release Notes from deployed pages

## Changes Made

- toctree in index pages updated