### PR TITLE
fix(model): refactor ip router model

### DIFF
--- a/docs/source/flync_reference/submodels/flync_4_ecu.rst
+++ b/docs/source/flync_reference/submodels/flync_4_ecu.rst
@@ -207,6 +207,16 @@ TCAM
 .. autoclass:: flync.model.flync_4_ecu.switch.RemoveVLAN()
 
 
+
+.. _router:
+
+Router Config
+#############
+
+.. autoclass:: flync.model.flync_4_ecu.router.RouteEntry()
+
+
+
 .. _phy:
 
 PHY Config

--- a/src/flync/model/flync_4_ecu/__init__.py
+++ b/src/flync/model/flync_4_ecu/__init__.py
@@ -22,6 +22,7 @@ from .mac_multicast_endpoint import (
 from .multicast_groups import MulticastGroupMembership
 from .phy import BASET, BASET1, BASET1S, MII, RGMII, RMII, SGMII, XFI
 from .port import ECUPort
+from .router import RouteEntry
 from .socket_container import SocketContainer
 from .sockets import (
     IPv4AddressEndpoint,
@@ -33,9 +34,7 @@ from .sockets import (
     UDPOption,
 )
 from .switch import (
-    RouteEntry,
     Switch,
-    SwitchHostController,
     SwitchPort,
     TCAMRule,
     TrafficClass,
@@ -71,7 +70,6 @@ __all__ = [
     "ECUPort",
     "RouteEntry",
     "Switch",
-    "SwitchHostController",
     "SwitchPort",
     "VLANEntry",
     "MulticastGroup",

--- a/src/flync/model/flync_4_ecu/controller.py
+++ b/src/flync/model/flync_4_ecu/controller.py
@@ -32,6 +32,7 @@ from flync.core.version_migrators.legacy_controller_check import (
     reject_legacy_controller,
 )
 from flync.model.flync_4_ecu.phy import MII, RGMII, RMII, SGMII, XFI
+from flync.model.flync_4_ecu.router import RouteEntry, gateway_in_subnet
 from flync.model.flync_4_ecu.socket_container import SocketContainer
 from flync.model.flync_4_ecu.sockets import (
     IPv4AddressEndpoint,
@@ -291,6 +292,11 @@ class ControllerInterface(NamedDictInstances):
     traffic_classes : list of :class:`~flync.model.flync_4_tsn.TrafficClass`, optional
         Traffic class definitions and egress queue shaping configuration.
 
+    routing_table : list of :class:`~flync.model.flync_4_ecu.router.RouteEntry`, optional
+        Static routing table for forwarding between subnets.
+        When provided, this interface acts as an IP router.
+        Each entry maps a destination network to a ``default_gateway`` IP and an ``egress_interface`` (VCI name).
+
     Private Attributes
     ------------------
     _connected_component :
@@ -319,6 +325,10 @@ class ControllerInterface(NamedDictInstances):
     htb: _HTBField = Field(default=None)
     ingress_streams: _IngressStreamsField = Field(default=[])
     traffic_classes: _TrafficClassesField = Field(default_factory=list)
+    routing_table: Annotated[
+        Optional[List[RouteEntry]],
+        BeforeValidator(common_validators.none_to_empty_list),
+    ] = Field(default=[])
     _connected_component = PrivateAttr(default=None)
     _type: Literal["controller_interface"] = PrivateAttr(default="controller_interface")
     _controller: Optional["Controller"] = PrivateAttr(default=None)
@@ -386,6 +396,47 @@ class ControllerInterface(NamedDictInstances):
                     raise err_minor(
                         f"{feature} is configured on both controller interface {self.name} and compute node "
                         f"{node.name}. It must be defined on either the interface or its compute nodes, not both."
+                    )
+        return self
+
+    @model_validator(mode="after")
+    def validate_routing_table_egress_interface(self):
+        """
+        Validate that every ``egress_interface`` in the routing table exists as a VCI on this interface.
+
+        Raises:
+            err_minor: An ``egress_interface`` is not a VCI of this interface.
+        """
+        if self.routing_table:
+            all_vcis = list(self.virtual_interfaces or [])
+            for node in self.compute_nodes or []:
+                all_vcis.extend(node.virtual_interfaces or [])
+            vci_names = [vci.name for vci in all_vcis]
+            for route in self.routing_table:
+                if route.egress_interface not in vci_names:
+                    raise err_minor(f"RouteEntry egress_interface {route.egress_interface} is not a virtual interface of the controller interface.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_routing_table_default_gateway(self):
+        """
+        Validate that ``default_gateway`` of each route falls within the subnet of its ``egress_interface`` VCI.
+
+        Raises:
+            err_minor: ``default_gateway`` is not within the subnet of the ``egress_interface`` VCI.
+        """
+        if self.routing_table:
+            all_vcis = list(self.virtual_interfaces or [])
+            for node in self.compute_nodes or []:
+                all_vcis.extend(node.virtual_interfaces or [])
+            vci_map = {vci.name: vci for vci in all_vcis}
+            for route in self.routing_table:
+                vci = vci_map.get(route.egress_interface)
+                if vci is None:
+                    continue
+                if not gateway_in_subnet(route, vci):
+                    raise err_minor(
+                        f"RouteEntry default_gateway {route.default_gateway} is not within the subnet of egress_interface {route.egress_interface}."
                     )
         return self
 

--- a/src/flync/model/flync_4_ecu/router.py
+++ b/src/flync/model/flync_4_ecu/router.py
@@ -1,0 +1,69 @@
+"""Defines the IP routing models and utilities for FLYNC controllers."""
+
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
+
+from pydantic import Field
+from pydantic.networks import IPvAnyAddress
+
+from flync.core.base_models.base_model import FLYNCBaseModel
+from flync.core.datatypes.ipaddress import IPv4AddressEntry, IPv6AddressEntry
+from flync.model.flync_4_ecu.sockets import IPv4AddressEndpoint, IPv6AddressEndpoint
+
+
+class RouteEntry(FLYNCBaseModel):
+    """
+    Represents a static routing table entry.
+
+    Parameters
+    ----------
+    destination : :class:`~flync.core.datatypes.ipaddress.IPv4AddressEntry` or :class:`~flync.core.datatypes.ipaddress.IPv6AddressEntry`
+        The destination network expressed as address and mask (e.g. ``address="10.0.0.0", ipv4netmask="255.255.255.0"``).
+
+    default_gateway : :class:`~pydantic.networks.IPvAnyAddress`
+        Gateway IP for this route.
+        If the next hop is a router, this is that router's VCI address on the shared subnet.
+        If the next hop is a controller interface (directly connected), this is the controller interface's IP address.
+
+    egress_interface : str
+        Name of the :class:`~flync.model.flync_4_ecu.controller.VirtualControllerInterface` on this interface
+        through which this route is forwarded.
+    """
+
+    destination: IPv4AddressEntry | IPv6AddressEntry = Field()
+    default_gateway: IPvAnyAddress = Field()
+    egress_interface: str = Field()
+
+
+def gateway_in_subnet(route: RouteEntry, vci) -> bool:
+    """
+    Return ``True`` if ``route.default_gateway`` falls within any address subnet configured on ``vci``.
+
+    Parameters
+    ----------
+    route : :class:`RouteEntry`
+        The routing table entry whose ``default_gateway`` is being validated.
+
+    vci : :class:`~flync.model.flync_4_ecu.controller.VirtualControllerInterface`
+        The virtual controller interface to check against. Its ``addresses`` list is used to derive the subnet(s).
+    """
+    for addr_entry in vci.addresses:
+        if (
+            isinstance(addr_entry, IPv4AddressEndpoint)
+            and isinstance(route.default_gateway, IPv4Address)
+            and route.default_gateway
+            in IPv4Network(
+                f"{addr_entry.address}/{addr_entry.ipv4netmask}",
+                strict=False,
+            )
+        ) or (
+            isinstance(addr_entry, IPv6AddressEndpoint)
+            and isinstance(route.default_gateway, IPv6Address)
+            and route.default_gateway
+            in IPv6Network(
+                f"{addr_entry.address}/{addr_entry.ipv6prefix}",
+                strict=False,
+            )
+        ):
+            return True
+
+    return False

--- a/src/flync/model/flync_4_ecu/switch.py
+++ b/src/flync/model/flync_4_ecu/switch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from typing import (
     Annotated,
     List,
@@ -19,7 +18,6 @@ from pydantic import (
     StrictInt,
     model_validator,
 )
-from pydantic.networks import IPvAnyAddress
 
 import flync.core.utils.common_validators as common_validators
 from flync.core.base_models import (
@@ -27,7 +25,6 @@ from flync.core.base_models import (
     NamedListInstances,
 )
 from flync.core.base_models.base_model import FLYNCBaseModel
-from flync.core.datatypes.ipaddress import IPv4AddressEntry, IPv6AddressEntry
 from flync.core.utils.common_validators import validate_vlan_id
 from flync.core.utils.exceptions import err_minor
 from flync.model.flync_4_ecu.controller import ControllerInterface
@@ -40,10 +37,6 @@ from flync.model.flync_4_ecu.phy import (
     RMII,
     SGMII,
     XFI,
-)
-from flync.model.flync_4_ecu.sockets import (
-    IPv4AddressEndpoint,
-    IPv6AddressEndpoint,
 )
 from flync.model.flync_4_ecu.vlan_entry import VLANEntry
 from flync.model.flync_4_metadata import EmbeddedMetadata
@@ -363,52 +356,6 @@ class TCAMRule(FLYNCBaseModel):
         return self
 
 
-class RouteEntry(FLYNCBaseModel):
-    """
-    Represents a static routing table entry.
-
-    Parameters
-    ----------
-    destination : :class:`~flync.core.datatypes.ipaddress.IPv4AddressEntry` or :class:`~flync.core.datatypes.ipaddress.IPv6AddressEntry`
-        The destination network expressed as address and mask (e.g. ``address="10.0.0.0", ipv4netmask="255.255.255.0"``).
-
-    default_gateway : :class:`~pydantic.networks.IPvAnyAddress`
-        Gateway IP for this route.
-        If the next hop is another switch, this is that switch's VCI address on the shared subnet.
-        If the next hop is a controller interface (directly connected), this is the controller interface's IP address.
-
-    egress_interface : str
-        Name of the host controller's virtual interface (VCI) through which this route is forwarded.
-    """
-
-    destination: IPv4AddressEntry | IPv6AddressEntry = Field()
-    default_gateway: IPvAnyAddress = Field()
-    egress_interface: str = Field()
-
-
-class SwitchHostController(ControllerInterface):
-    """
-    Represents an internal controller that manages a switch.
-
-    Extends :class:`~flync.model.flync_4_ecu.controller.ControllerInterface` with an optional static routing table.
-    All standard controller interface features are supported.
-    When a ``routing_table`` is provided, the host controller additionally acts as an IP router between subnets, with each subnet's gateway IP
-    hosted on the corresponding :class:`~flync.model.flync_4_ecu.controller.VirtualControllerInterface`.
-
-    Parameters
-    ----------
-    routing_table : list of :class:`RouteEntry`, optional
-        Static routing table for L3 forwarding between subnets.
-        Each entry maps a destination network (address + mask) to a ``default_gateway`` IP and an ``egress_interface`` (VCI name) on
-        the host controller through which the traffic is forwarded.
-    """
-
-    routing_table: Annotated[
-        Optional[List[RouteEntry]],
-        BeforeValidator(common_validators.none_to_empty_list),
-    ] = Field(default=[])
-
-
 class Switch(NamedListInstances):
     """
     Represents an automotive Ethernet network switch configuration.
@@ -427,9 +374,8 @@ class Switch(NamedListInstances):
     vlans : list of :class:`~flync.model.flync_4_ecu.vlan_entry.VLANEntry`
         List of VLAN entries configured on the switch.
 
-    host_controller : :class:`SwitchHostController`, optional
-        Internal controller that manages the switch.
-        Supports all the standard controller interface features and optionally L3 IP routing via a routing table.
+    host_controller : :class:`~flync.model.flync_4_ecu.controller.ControllerInterface`, optional
+        Internal controller interface that manages the switch.
 
     tcam_rules : list of :class:`TCAMRule`, optional
         List of TCAM rules configured on the switch.
@@ -444,7 +390,7 @@ class Switch(NamedListInstances):
     ] = Field(default=[])
     ports: List[SwitchPort] = Field()
     vlans: List[VLANEntry] = Field()
-    host_controller: Optional[SwitchHostController] = Field(default=None)
+    host_controller: Optional[ControllerInterface] = Field(default=None)
     meta: EmbeddedMetadata = Field()
 
     @model_validator(mode="after")
@@ -565,72 +511,6 @@ class Switch(NamedListInstances):
         common_validators.validate_list_items_unique(names, "tcam_rules (name)")
 
         return self
-
-    @model_validator(mode="after")
-    def validate_routing_table_egress_interface(self):
-        """
-        Validate that every ``egress_interface`` in the routing table exists as a VCI on the host controller of the switch.
-
-        Raises:
-            err_minor: An ``egress_interface`` is not a VCI of the host controller.
-        """
-
-        if not self.host_controller or not self.host_controller.routing_table:
-            return self
-        vci_names = [vci.name for vci in self.host_controller.virtual_interfaces]
-        for route in self.host_controller.routing_table:
-            if route.egress_interface not in vci_names:
-                raise err_minor(f"RouteEntry egress_interface {route.egress_interface}" f" is not a virtual interface of the host_controller.")
-        return self
-
-    @model_validator(mode="after")
-    def validate_routing_table_default_gateway(self):
-        """
-        Validate that ``default_gateway`` of each route falls within the subnet of its ``egress_interface`` VCI.
-
-        Raises:
-            err_minor: ``default_gateway`` is not within the subnet of the ``egress_interface`` VCI.
-        """
-
-        if not self.host_controller or not self.host_controller.routing_table:
-            return self
-        vci_map = {vci.name: vci for vci in self.host_controller.virtual_interfaces}
-        for route in self.host_controller.routing_table:
-            vci = vci_map.get(route.egress_interface)
-            if vci is None:
-                continue
-            if not self.gateway_in_subnet(route, vci):
-                raise err_minor(
-                    f"RouteEntry default_gateway {route.default_gateway} is not within the subnet of egress_interface" f" {route.egress_interface}."
-                )
-        return self
-
-    def gateway_in_subnet(self, route, vci) -> bool:
-        """
-        Return ``True`` if ``route.default_gateway`` falls within any address subnet configured on ``vci``.
-        """
-
-        for addr_entry in vci.addresses:
-            if (
-                isinstance(addr_entry, IPv4AddressEndpoint)
-                and isinstance(route.default_gateway, IPv4Address)
-                and route.default_gateway
-                in IPv4Network(
-                    f"{addr_entry.address}/{addr_entry.ipv4netmask}",
-                    strict=False,
-                )
-                or (
-                    isinstance(addr_entry, IPv6AddressEndpoint)
-                    and isinstance(route.default_gateway, IPv6Address)
-                    and route.default_gateway
-                    in IPv6Network(
-                        f"{addr_entry.address}/{addr_entry.ipv6prefix}",
-                        strict=False,
-                    )
-                )
-            ):
-                return True
-        return False
 
     def get_mac(self):
         return self.host_controller.mac_address


### PR DESCRIPTION
<!-- MAKE SURE TO REMOVE ANY SECTIONS/PARTS/CHECKPOINTS THAT ARE NOT RELEVANT TO YOUR PR -->

## Description

RouteEntry moved from switch.py to router.py.
Validators validate_routing_table_egress_interface and validate_routing_table_default_gateway moved from switch.py to controllers.py under ControllerInterface

## Related Issues/PRs

FLYNC-1058