### PR TITLE
docs (computeNode, L2Bridge): add experimental warning 

### DIFF
--- a/src/flync/model/flync_4_ecu/controller.py
+++ b/src/flync/model/flync_4_ecu/controller.py
@@ -27,7 +27,7 @@ from flync.core.base_models import (
     NamedDictInstances,
     NamedListInstances,
 )
-from flync.core.utils.exceptions import err_fatal, err_major, err_minor
+from flync.core.utils.exceptions import err_fatal, err_major, err_minor, warn
 from flync.core.version_migrators.legacy_controller_check import (
     reject_legacy_controller,
 )
@@ -122,6 +122,8 @@ class VirtualControllerInterface(FLYNCBaseModel):
 
 class ComputeNodes(FLYNCBaseModel):
     """
+    **WARNING: ComputeNode is currently experimental! Subject to change, please use with care.**
+
     A virtual machine (VM) attached to a controller interface.
 
     Compute nodes are VMs that run on the same SoC as the controller.
@@ -187,6 +189,12 @@ class ComputeNodes(FLYNCBaseModel):
         """Ensure no ingress stream carries an ipv or ats value."""
         return common_validators.validate_ingress_streams_fields(value, "compute node")
 
+    @model_validator(mode="before")
+    def experimental_warning(self):
+        """Experimental Class in v0.11.0"""
+        warn("Compute Nodes are currently experimental! Subject to change, please use with care.")
+        return self
+
     @model_validator(mode="after")
     def validate_vlans(self):
         """Raise if any VLAN ID is repeated across virtual interfaces."""
@@ -216,6 +224,8 @@ class L2BridgePort(FLYNCBaseModel):
 
 class L2Bridge(FLYNCBaseModel):
     """
+    **WARNING: L2Bridge is currently experimental! Subject to change, please use with care.**
+
     A software MAC bridge inside a controller.
 
     The L2 bridge is the connectivity fabric that ties together the controller's physical interfaces and their compute nodes.
@@ -239,6 +249,12 @@ class L2Bridge(FLYNCBaseModel):
     name: str = Field()
     ports: List[L2BridgePort] = Field()
     vlans: List[VLANEntry] = Field()
+
+    @model_validator(mode="before")
+    def experimental_warning(self):
+        """Experimental Class in v0.11.0"""
+        warn("L2Bridge is currently experimental! Subject to change, please use with care.")
+        return self
 
 
 class ControllerInterface(NamedDictInstances):

--- a/tests/unit_test/sdk/test_helpers.py
+++ b/tests/unit_test/sdk/test_helpers.py
@@ -82,8 +82,7 @@ TEST_OBJECTS_PATHS = [
 
 def test_workspace_validator_api(get_flync_example_path):
     validation_result = validate_workspace(get_flync_example_path)
-    assert validation_result.state == WorkspaceState.VALID
-    assert not validation_result.errors
+    assert (validation_result.state == WorkspaceState.VALID) or (validation_result.state == WorkspaceState.WARNING)
     assert validation_result.workspace is not None
     assert validation_result.model is not None
     assert validation_result.workspace.flync_model == validation_result.model
@@ -229,7 +228,7 @@ def test_generate_partial_external_node(node_type, node_path):
     to_check_output_file.mkdir(parents=True, exist_ok=True)
     shutil.copytree(output_path, to_check_output_file, dirs_exist_ok=True)
     ws_validation = validate_external_node(node_type, to_check_output_file)
-    assert ws_validation.state == WorkspaceState.VALID
+    assert (ws_validation.state == WorkspaceState.VALID) or (ws_validation.state == WorkspaceState.WARNING)
     assert len(ws_validation.errors) == 0
     assert isinstance(ws_validation.model, node_type)
 
@@ -263,7 +262,7 @@ def test_generate_partial_node(get_flync_example_path, node_type, node_path):
     to_check_output_file.mkdir(parents=True, exist_ok=True)
     shutil.copytree(output_path, to_check_output_file, dirs_exist_ok=True)
     ws_validation = validate_workspace(to_check_output_file, generated_workspace.configuration)
-    assert ws_validation.state == WorkspaceState.VALID
+    assert (ws_validation.state == WorkspaceState.VALID) or (ws_validation.state == WorkspaceState.WARNING)
     assert len(ws_validation.errors) == 0
     assert any(p in ws_validation.workspace.objects for p in node_path)
     assert isinstance(ws_validation.workspace.get_object(node_path[0]).model, node_type)
@@ -296,7 +295,7 @@ def test_flync_extension(get_flync_example_path):
         yaml.dump(extra_data, f, default_flow_style=False)
 
     output = validate_external_node(ExtendedFLYNC, output_extra_path)
-    assert output.state == WorkspaceState.VALID
+    assert (output.state == WorkspaceState.VALID) or (output.state == WorkspaceState.WARNING)
     created_model: ExtendedFLYNC = output.model
     assert created_model.extra.extra_name == "value"
 


### PR DESCRIPTION
Added warning into docstrings and model validator in both classes:

<img width="918" height="210" alt="grafik" src="https://github.com/user-attachments/assets/1a1a3d76-9db8-4f75-ba4a-a41f589b8801" />


<img width="894" height="216" alt="grafik" src="https://github.com/user-attachments/assets/0d6eef07-c414-494e-b93b-a26f602fd856" />
