### PR TITLE
Hotfix: Add default value for optional Vlan 

### DIFF
--- a/src/flync/model/flync_4_ecu/controller.py
+++ b/src/flync/model/flync_4_ecu/controller.py
@@ -108,7 +108,7 @@ class VirtualControllerInterface(FLYNCBaseModel):
     vlanid: Annotated[
         Optional[int],
         AfterValidator(common_validators.validate_vlan_id),
-    ] = Field(...)
+    ] = Field(default=None)
     addresses: List[IPv6AddressEndpoint | IPv4AddressEndpoint] = Field()
     multicast: Annotated[
         Optional[List[IPvAnyAddress | MacAddress]],

--- a/src/flync/model/flync_4_ecu/mac_multicast_endpoint.py
+++ b/src/flync/model/flync_4_ecu/mac_multicast_endpoint.py
@@ -44,14 +44,18 @@ class MACMulticastEndpoint(FLYNCBaseModel):
         description="EtherType that is expected on this endpoint.",
         ge=0x0000,
         le=0xFFFF,
+        default=None,
     )
-    vlan_id: Annotated[Optional[int], AfterValidator(validate_vlan_id)] = Field(
-        description="VLAN ID expected on this endpoint (``None`` for untagged).",
+    vlan_id: Annotated[Optional[int], AfterValidator(validate_vlan_id)] = (
+        Field(
+            description="VLAN ID expected on this endpoint (``None`` for untagged).",
+            default=None,
+        )
     )
     multicast_tx: Optional[List[Annotated[MacAddress, AfterValidator(validate_mac_multicast)]]] = Field(
         description="List of multicast addresses that this endpoint should \
             transmit to.",
-        default_factory=list,
+        default=[],
     )
 
 

--- a/src/flync/model/flync_4_ecu/mac_multicast_endpoint.py
+++ b/src/flync/model/flync_4_ecu/mac_multicast_endpoint.py
@@ -46,11 +46,9 @@ class MACMulticastEndpoint(FLYNCBaseModel):
         le=0xFFFF,
         default=None,
     )
-    vlan_id: Annotated[Optional[int], AfterValidator(validate_vlan_id)] = (
-        Field(
-            description="VLAN ID expected on this endpoint (``None`` for untagged).",
-            default=None,
-        )
+    vlan_id: Annotated[Optional[int], AfterValidator(validate_vlan_id)] = Field(
+        description="VLAN ID expected on this endpoint (``None`` for untagged).",
+        default=None,
     )
     multicast_tx: Optional[List[Annotated[MacAddress, AfterValidator(validate_mac_multicast)]]] = Field(
         description="List of multicast addresses that this endpoint should \

--- a/tests/unit_test/core/test_optional_field_defaults.py
+++ b/tests/unit_test/core/test_optional_field_defaults.py
@@ -1,0 +1,49 @@
+import types
+import typing
+
+import flync  # noqa: F401  -- imports every model module, populating __subclasses__
+
+from flync.core.base_models import FLYNCBaseModel
+
+
+def _all_subclasses(cls: type) -> set[type]:
+    seen: set[type] = set()
+    stack = list(cls.__subclasses__())
+    while stack:
+        sub = stack.pop()
+        if sub in seen:
+            continue
+        seen.add(sub)
+        stack.extend(sub.__subclasses__())
+    return seen
+
+
+def _annotation_accepts_none(annotation: object) -> bool:
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        return type(None) in typing.get_args(annotation)
+    return annotation is type(None)
+
+
+class TestOptionalFieldDefaults:
+
+    def test_nullable_fields_must_declare_a_default(self):
+        """Pydantic v2: Optional[X] only widens the type to allow None; it does
+        not make the field non-required. Any field whose annotation accepts
+        None must declare an explicit default (typically None) — otherwise
+        instantiation fails with ``Field required`` even though callers and
+        docstrings treat the field as optional."""
+
+        offenders: list[str] = []
+        for model_cls in _all_subclasses(FLYNCBaseModel):
+            if not model_cls.__module__.startswith("flync."):
+                continue
+            for field_name, field_info in model_cls.model_fields.items():
+                if _annotation_accepts_none(field_info.annotation) and field_info.is_required():
+                    offenders.append(f"{model_cls.__module__}.{model_cls.__name__}.{field_name}")
+
+        assert not offenders, (
+            "Fields whose annotation accepts None must declare a default "
+            "(e.g. ``default=None``); otherwise Pydantic still treats them as "
+            "required:\n  - " + "\n  - ".join(sorted(offenders))
+        )

--- a/tests/unit_test/core/test_optional_field_defaults.py
+++ b/tests/unit_test/core/test_optional_field_defaults.py
@@ -2,7 +2,6 @@ import types
 import typing
 
 import flync  # noqa: F401  -- imports every model module, populating __subclasses__
-
 from flync.core.base_models import FLYNCBaseModel
 
 


### PR DESCRIPTION
AVTPMulticastEndpoint was missing a default value on Optional VLAN, therefore raised Validation Error if no value was defined. 
I added also a testcase that checks the whole model for missing default values on optional fields