### PR TITLE
chore: improve validation script

### DIFF
--- a/src/flync/core/utils/exceptions_handling.py
+++ b/src/flync/core/utils/exceptions_handling.py
@@ -157,6 +157,27 @@ def _fallback_position(node: Any) -> Tuple[int | None, int | None]:
     )
 
 
+def _parse_first_sub_error_loc(sub_errors: str) -> tuple:
+    """Extract the loc path from the first line of a sub_errors string.
+
+    sub_errors lines have the format ``"dot.path: message"``.  The path is
+    split on ``.`` and integer-looking parts are converted to ``int`` so the
+    result can be appended to a Pydantic loc tuple for YAML navigation.
+    """
+    first_line = sub_errors.split("\n")[0]
+    colon_idx = first_line.find(": ")
+    if colon_idx <= 0:
+        return ()
+    parts: list[int | str] = []
+    for part in first_line[:colon_idx].split("."):
+        if part:
+            try:
+                parts.append(int(part))
+            except ValueError:
+                parts.append(part)
+    return tuple(parts)
+
+
 def errors_to_init_errors(
     errors: List[ErrorDetails],
     model: Optional[type[BaseModel]] = None,
@@ -193,6 +214,13 @@ def errors_to_init_errors(
             ctx["yaml_path"] = str(yaml_path)
         if model is not None and yaml_data and "yaml_location" not in ctx:
             line, col = safe_yaml_position(yaml_data, e["loc"], model=model)
+            sub_errors = ctx.get("sub_errors", "")
+            if sub_errors:
+                sub_loc = _parse_first_sub_error_loc(sub_errors)
+                if sub_loc:
+                    deep_line, deep_col = safe_yaml_position(yaml_data, e["loc"] + sub_loc)
+                    if deep_line is not None:
+                        line, col = deep_line, deep_col
             if line:
                 ctx["line"] = line
             if col:
@@ -318,12 +346,17 @@ def _wrap_native_error(err: ErrorDetails) -> ErrorDetails:
     loc = err.get("loc", ())
     field_name = loc[-1] if loc else "field"
     sub_errors = f"{original_type}: {original_msg}"
+    original_ctx = err.get("ctx") or {}
+    ctx: dict = {"sub_errors": sub_errors}
+    for key in ("yaml_path", "line", "col"):
+        if key in original_ctx:
+            ctx[key] = original_ctx[key]
     return {
         "type": "major",
         "msg": (f"1 or more errors found while validating {field_name}. Removing {field_name}."),
         "loc": loc,
         "input": err.get("input"),
-        "ctx": {"sub_errors": sub_errors},
+        "ctx": ctx,
         "url": "",
     }  # type: ignore[return-value]
 

--- a/src/flync/sdk/helpers/validate_workspace.py
+++ b/src/flync/sdk/helpers/validate_workspace.py
@@ -1,212 +1,191 @@
 """
-CLI script for validating a FLYNC workspace.
+CLI script for validating a FLYNC workspace or a specific node type.
 
 When run directly, accepts a path to a FLYNC configuration directory and validates it,
 printing any errors as a Rich table and exiting with a non-zero status code on failure.
+Use ``--node`` to validate a specific node type instead of the full workspace.
 """
 
 import argparse
 import re
 import sys
+import time
 from pathlib import Path
 
-from pydantic import ValidationError
-from pydantic_core import ErrorDetails
 from rich.console import Console
 from rich.table import Table
 
-from flync.sdk.workspace.flync_workspace import FLYNCWorkspace
+from flync.sdk.context.diagnostics_result import DiagnosticsResult, WorkspaceState
+from flync.sdk.helpers.validation_helpers import validate_external_node, validate_workspace
 
-PROJECT_BASE = Path(__file__).resolve().parent.parent
-VALIDATION_ERRORS: dict = {}
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+ERRORS_HEADER = "\n[bold red]Errors:[/bold red]"
 console = Console(force_terminal=True, legacy_windows=False)
 
 
+def sanitize_error_message(error_msg: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", error_msg)
+
+
 def _make_details_cell(sub_errors: str) -> Table | str:
-    """
-    Build a nested table for the Details column.
-
-    Each newline-separated sub-error gets its own row, separated by a horizontal rule, matching the visual pattern:
-
-        Error 1: abc not good
-        ─────────────────────
-        Error 2: DEF not good
-    """
-
+    """Build a nested table for the Details column, one row per sub-error."""
     if not sub_errors:
         return ""
     lines = [ln for ln in sub_errors.split("\n") if ln]
-    nested = Table(
-        show_header=False,
-        show_edge=False,
-        show_lines=True,
-        padding=(0, 1),
-    )
+    nested = Table(show_header=False, show_edge=False, show_lines=True, padding=(0, 1))
     nested.add_column("detail", style="magenta", overflow="fold")
     for i, line in enumerate(lines):
         nested.add_row(f"Error {i + 1}: {line}")
     return nested
 
 
-def sanitize_error_message(error_msg: str) -> str:
+def _format_source(doc_uri: str, raw_ctx: dict) -> str:
+    """Workspace-relative path and line number for an error or warning.
+
+    Both yaml_path (from ctx) and doc_uri are already workspace-relative
+    (doc_uri = path.absolute().relative_to(workspace_root).as_posix()).
     """
-    Strip ANSI escape codes from an error message string.
+    path = str(raw_ctx.get("yaml_path", "")) or doc_uri
+    line = raw_ctx.get("line")
+    return f"{path}:line {line}" if line is not None else path
 
-    Args:
-        error_msg (str): The raw error message, potentially containing ANSI
-            colour sequences.
 
-    Returns:
-        str: The message with all ANSI escape codes removed.
+def render_warnings(result: DiagnosticsResult) -> None:
+    rows = [(doc_uri, err) for doc_uri, errs in result.errors.items() for err in errs if err.get("type") == "warning"]
+    if not rows:
+        return
+    console.print("\n[bold yellow]Warnings:[/bold yellow]")
+    table = Table(show_lines=True)
+    table.add_column("#", justify="right")
+    table.add_column("Warning Type", style="yellow", overflow="fold")
+    table.add_column("Message", style="white", overflow="fold")
+    table.add_column("Source", style="green", overflow="fold")
+    for idx, (doc_uri, err) in enumerate(rows, 1):
+        table.add_row(
+            str(idx),
+            err.get("type", ""),
+            sanitize_error_message(err.get("msg", "")),
+            _format_source(doc_uri, err.get("ctx", {})),
+        )
+    console.print(table)
+
+
+def _classify_errors(errors_by_doc: dict) -> tuple[list, list]:
+    """Split non-warning (doc_uri, err) pairs into (root_rows, subsequent_rows).
+
+    The workspace loads documents in two structural roles:
+    - ``.flync.yaml`` files   — validated against their own YAML content; any error
+      here is a genuine problem in that file (root cause).
+    - Directory documents     — assembled from child models that returned ``None``
+      when they failed; errors here exist *only* because a child document failed
+      (subsequent).
+
+    ``doc_uri`` is the workspace-relative POSIX path produced by
+    ``document_id_from_path``.  File documents always carry a ``.yaml`` suffix;
+    directory documents have no suffix.
     """
 
-    return ANSI_ESCAPE_RE.sub("", error_msg)
+    root_rows: list[tuple[str, dict]] = []
+    subsequent_rows: list[tuple[str, dict]] = []
+    for doc_uri, errs in errors_by_doc.items():
+        is_file_doc = bool(Path(doc_uri).suffix)
+        for err in errs:
+            if err.get("type") == "warning":
+                continue
+            (root_rows if is_file_doc else subsequent_rows).append((doc_uri, err))
+    return root_rows, subsequent_rows
 
 
-def __add_pydantic_errors_to_report(
-    pydantic_validation_errors: list[ErrorDetails],
-    error_list: list,
-):
-    """
-    Append formatted rows for Pydantic errors to a report list.
+def _make_error_table() -> Table:
+    table = Table(show_lines=True)
+    table.add_column("#", justify="right")
+    table.add_column("Error Type", style="red", overflow="fold")
+    table.add_column("Message", style="yellow", overflow="fold")
+    table.add_column("Location", style="cyan", overflow="fold")
+    table.add_column("Source", style="green", overflow="fold")
+    table.add_column("Details", style="magenta", overflow="fold")
+    return table
 
-    Each error is flattened into a ``[type, message, location, context]``
-    row and appended to ``error_list`` in place.
 
-    Args:
-        pydantic_validation_errors (list[ErrorDetails]): Pydantic error detail
-            dicts as returned by ``ValidationError.errors()``.
-        error_list (list): The mutable list to append formatted rows to.
-    """
-
-    for err in pydantic_validation_errors:
-        location = ".".join(str(p) for p in err.get("loc", []))
-        err_type = err.get("type", "")
-        msg = err.get("msg", "")
+def _fill_error_table(table: Table, rows: list, start_idx: int) -> None:
+    for idx, (doc_uri, err) in enumerate(rows, start_idx):
         raw_ctx = err.get("ctx", {})
-        sub_errors = raw_ctx.get("sub_errors", "")
-        ctx = ", ".join(f"{k}={v}" for k, v in raw_ctx.items() if k != "sub_errors")
-        error_list.append([err_type, msg, location, ctx, sub_errors])
+        table.add_row(
+            str(idx),
+            err.get("type", ""),
+            sanitize_error_message(err.get("msg", "")),
+            ".".join(str(p) for p in err.get("loc", [])),
+            _format_source(doc_uri, raw_ctx),
+            _make_details_cell(raw_ctx.get("sub_errors", "")),
+        )
 
 
-def add_errors_to_report(
-    errors_report,
-    config_name: str,
-    exc: Exception,
-):
-    """
-    Record an exception as formatted error rows in a report dictionary.
+def render_errors(result: DiagnosticsResult, only_root: bool = True) -> None:
+    all_rows = [(doc_uri, err) for doc_uri, errs in result.errors.items() for err in errs if err.get("type") != "warning"]
+    if result.state == WorkspaceState.BROKEN and not all_rows:
+        console.print(ERRORS_HEADER)
+        console.print("[red]  Workspace could not be loaded (BROKEN)[/red]")
+        return
+    if not all_rows:
+        return
 
-    Handles both :class:`pydantic.ValidationError` (expanded field-by-field) and generic exceptions (treated as a single row).
+    root_rows, subsequent_rows = _classify_errors(result.errors)
 
-    Args:
-        errors_report (dict): Mapping of config names to lists of error rows.
-            Updated in place.
-        config_name (str): Key under which the errors are stored.
-        exc (Exception): The exception to record.
+    if root_rows:
+        console.print(ERRORS_HEADER)
+        table = _make_error_table()
+        _fill_error_table(table, root_rows, 1)
+        console.print(table)
 
-    Returns:
-        dict: The updated ``errors_report`` mapping.
-    """
-
-    errs: list = []
-
-    if isinstance(exc, ValidationError):
-        pydantic_validation_errors = exc.errors()
-        __add_pydantic_errors_to_report(pydantic_validation_errors, errs)
-    else:
-        # Generic exception handling
-        location = ""
-        err_type = type(exc).__name__
-        msg = sanitize_error_message(str(exc))
-        ctx = ""
-        errs.append([err_type, msg, location, ctx, ""])
-
-    errors_report[config_name] = errs
-    return errors_report
-
-
-def render_validation_errors(errors: dict) -> None:
-    """Display FLYNC project validation errors as a Rich table."""
-    for config_name, errs in errors.items():
-        console.print(f"\n[bold red]Errors for {config_name}:[/bold red]")
-        table = Table(show_lines=True)
-        table.add_column("Num.", justify="right")
-        table.add_column("Error Type", style="red", overflow="fold")
-        table.add_column("Message", style="yellow", overflow="fold")
-        table.add_column("Location", style="cyan", overflow="fold")
-        table.add_column("Context", style="green", overflow="fold")
-        table.add_column("Details", style="magenta", overflow="fold")
-        for idx, error_row in enumerate(errs, 1):
-            *main_cols, sub = error_row
-            table.add_row(str(idx), *main_cols, _make_details_cell(sub))
+    if not only_root and subsequent_rows:
+        if root_rows:
+            console.print("\n[bold yellow]Subsequent Errors[/bold yellow]" "[dim](likely caused by the root errors above — fix those first):[/dim]")
+        else:
+            console.print(ERRORS_HEADER)
+        table = _make_error_table()
+        _fill_error_table(table, subsequent_rows, len(root_rows) + 1)
         console.print(table)
 
 
-parser = argparse.ArgumentParser(description="Script to validate a FLYNC workspace.")
-parser.add_argument("path", help="Absolute path to FLYNC configuration.")
+parser = argparse.ArgumentParser(description="Validate a FLYNC workspace or a specific node.")
+parser.add_argument("path", help="Path to the FLYNC configuration directory.")
 parser.add_argument(
     "-n",
     "--name",
     default="flync_config",
     help="Name of FLYNC configuration.",
 )
+parser.add_argument(
+    "--node",
+    metavar="NODE",
+    help="Node type name to validate via validate_external_node. Omit to validate the full workspace.",
+)
+parser.add_argument("-q", "--quiet", action="store_true", help="Only show final result of the validation.")
+parser.add_argument("-a", "--all", action="store_false", help="Shows all results, including warnings, errors and subsequent errors.")
 args = parser.parse_args()
 
 path = Path(args.path)
-flync_name = args.name
+flync_name = args.node or args.name
 
 if not path.exists():
     print(f"Error: Path does not exist: {path}", file=sys.stderr)
     sys.exit(1)
 
-
 console.print(f"Validating {flync_name} ...")
-loaded_ws = None
-VALIDATION_WARNINGS: dict = {}
-VALIDATION_SOFT_ERRORS: dict = {}
-try:
-    loaded_ws = FLYNCWorkspace.load_workspace(flync_name, path.resolve())
-except Exception as e:
-    console.print("[bold red]VALIDATION FAILED: Validation of {flync_name} failed![/bold red]")
-    if isinstance(e, ValidationError):
-        all_errs = e.errors()
-        warn_rows = [x for x in all_errs if x.get("type") == "warning"]
-        err_rows = [x for x in all_errs if x.get("type") != "warning"]
-        if warn_rows:
-            VALIDATION_WARNINGS[flync_name] = []
-            __add_pydantic_errors_to_report(warn_rows, VALIDATION_WARNINGS[flync_name])
-        if err_rows:
-            err_list: list = []
-            __add_pydantic_errors_to_report(err_rows, err_list)
-            VALIDATION_ERRORS[flync_name] = err_list
-    else:
-        VALIDATION_ERRORS = add_errors_to_report(VALIDATION_ERRORS, flync_name, e)
-if loaded_ws and loaded_ws.load_errors:
-    actual_warnings = [e for e in loaded_ws.load_errors if e.get("type") == "warning"]
-    soft_errors = [e for e in loaded_ws.load_errors if e.get("type") != "warning"]
-    if actual_warnings:
-        VALIDATION_WARNINGS[flync_name] = []
-        __add_pydantic_errors_to_report(actual_warnings, VALIDATION_WARNINGS[flync_name])
-    if soft_errors:
-        VALIDATION_SOFT_ERRORS[flync_name] = []
-        __add_pydantic_errors_to_report(soft_errors, VALIDATION_SOFT_ERRORS[flync_name])
+start = time.monotonic()
 
-for config_name, warnings in VALIDATION_WARNINGS.items():
-    console.print(f"\n[bold yellow]Warnings for {config_name}:[/bold yellow]")
-    table = Table(show_lines=True)
-    table.add_column("Num.", justify="right")
-    table.add_column("Warning Type", style="yellow", overflow="fold")
-    table.add_column("Message", style="white", overflow="fold")
-    for idx, warning_row in enumerate(warnings, 1):
-        table.add_row(str(idx), warning_row[0], warning_row[1])
-    console.print(table)
+result = validate_external_node(args.node, path.resolve()) if args.node else validate_workspace(path.resolve())
 
-render_validation_errors(VALIDATION_SOFT_ERRORS)
-render_validation_errors(VALIDATION_ERRORS)
-if len(VALIDATION_ERRORS) == 0:
-    console.print(f"[bold green]>> {flync_name} is properly configured! <<[/bold green]")
-    sys.exit(0)
-else:
+console.print(f">>> Elapsed time to load: {time.monotonic() - start:.2f}s")
+
+if not args.quiet:
+    render_warnings(result)
+    render_errors(result, args.all)
+
+has_errors = any(err.get("type") != "warning" for errs in result.errors.values() for err in errs)
+if result.state in (WorkspaceState.BROKEN, WorkspaceState.INVALID) or has_errors:
+    console.print(f"[bold red]>> VALIDATION FAILED for {flync_name} <<[/bold red]")
     sys.exit(1)
+
+console.print(f"[bold green]>> {flync_name} is properly configured! <<[/bold green]")
+sys.exit(0)


### PR DESCRIPTION
Changes:

1. Validation script previously returned some inconsistend messages in the end. Fixed now: 
   - if all is ok or only warnings -> prints ok
   - if there is errors -> prints Validation failed
2. Update CLI args
   - "-n" or "--node" option to use the validate_external_nodes (e.g. for isolated ECU or SOMEIP validation), this is also already used in the pipeline to validate ecu variant examples (I added that before but changes seem to got lost)
   - "-a" or "--all" to show also subsequent errors
   - "-q" or "--quiet" to only show the result
3. Improve output overall: 
   - using sdk API functions to validate
   - line of error is again shown in the error context
   - split root error and subsequent error (per default only root errors are shown)
   - printing elapsed time to load
