### PR TITLE
chore(sdk): improve loader time

### DIFF
--- a/src/flync/sdk/utils/model_dependencies.py
+++ b/src/flync/sdk/utils/model_dependencies.py
@@ -134,7 +134,7 @@ def _extract_model_dependencies(model: type[BaseModel], visited: set[type[BaseMo
         return {"__cycle__": True}
     visited.add(model)
     # Ensure forward refs are resolved
-    model.model_rebuild(force=True)
+    model.model_rebuild()
     deps = {}
 
     for name, field in model.model_fields.items():
@@ -553,6 +553,8 @@ class ModelDependencyGraph:
 
 _cache_cleaned = False
 _cache_name = ""
+_graph_memo: dict[str, "ModelDependencyGraph"] = {}
+_CACHE_SIGNATURE_FILE = "dependency_graph_cache_signature"
 
 
 def hash_directory_fast(directory: str, ext=".py") -> str:
@@ -605,23 +607,65 @@ def delete_unwanted_cache_files(cache_location: str, cache_file_name: str):
     """
 
     for f in listdir(cache_location):
-        if cache_file_name not in f:
+        if cache_file_name not in f and f != _CACHE_SIGNATURE_FILE:
             remove(join(cache_location, f))
+
+
+def _read_cached_signature(shelv_location: str, package_root: str) -> str | None:
+    """
+    Return the persisted package hash if the package directory's mtime matches.
+
+    Falling back when the signature file is missing, malformed, or when the
+    package directory's mtime has shifted since the last write. The directory
+    mtime catches structural changes (files added/removed); for in-place edits
+    in editable installs, run ``rm -rf $(python -c 'import platformdirs;
+    print(platformdirs.user_cache_dir("FLYNC"))')`` to force a rehash.
+    """
+
+    sig_path = join(shelv_location, _CACHE_SIGNATURE_FILE)
+    try:
+        with open(sig_path, "r", encoding="utf-8") as f:
+            stored_root, stored_mtime, stored_hash = f.read().strip().split("\t")
+        if stored_root != package_root:
+            return None
+        if stored_mtime != str(stat(package_root).st_mtime):
+            return None
+        return stored_hash
+    except (OSError, ValueError):
+        return None
+
+
+def _write_cached_signature(shelv_location: str, package_root: str, hash_value: str) -> None:
+    """Persist the package hash + directory mtime so future processes can skip the walk."""
+
+    sig_path = join(shelv_location, _CACHE_SIGNATURE_FILE)
+    try:
+        mtime = str(stat(package_root).st_mtime)
+        with open(sig_path, "w", encoding="utf-8") as f:
+            f.write(f"{package_root}\t{mtime}\t{hash_value}")
+    except OSError:
+        pass
 
 
 def cleanup_old_caches():
     """Resets the cache of the library if the current version is different."""
     global _cache_cleaned, _cache_name
     shelv_location = platformdirs.user_cache_dir("FLYNC")
-    if not _cache_name:
-        # only keep official version cache
-        makedirs(shelv_location, exist_ok=True)
-        shelv_file_name = "dependency_graph_cache"
-        shelv_file_name += "_" + hash_directory_fast(get_package_root())
+    if _cache_name:
+        return shelv_location, _cache_name
+    makedirs(shelv_location, exist_ok=True)
+    package_root = get_package_root()
+    cached_hash = _read_cached_signature(shelv_location, package_root)
+    if cached_hash is not None:
+        shelv_file_name = "dependency_graph_cache_" + cached_hash
+    else:
+        new_hash = hash_directory_fast(package_root)
+        shelv_file_name = "dependency_graph_cache_" + new_hash
+        _write_cached_signature(shelv_location, package_root, new_hash)
         if not _cache_cleaned:
             delete_unwanted_cache_files(shelv_location, shelv_file_name)
             _cache_cleaned = True
-            _cache_name = shelv_file_name
+    _cache_name = shelv_file_name
     return shelv_location, _cache_name
 
 
@@ -640,9 +684,13 @@ def get_model_dependency_graph(root: type[BaseModel]) -> ModelDependencyGraph:
     """
 
     key = str(root)
+    if key in _graph_memo:
+        return _graph_memo[key]
     shelv_location, shelv_file_name = cleanup_old_caches()
     with _shelve_lock:
         with shelve.open(join(shelv_location, shelv_file_name)) as cache:
             if key not in cache:
                 cache[key] = ModelDependencyGraph(root)
-            return cache[key]
+            graph = cache[key]
+    _graph_memo[key] = graph
+    return graph

--- a/src/flync/sdk/workspace/flync_workspace.py
+++ b/src/flync/sdk/workspace/flync_workspace.py
@@ -859,7 +859,7 @@ class FLYNCWorkspace(object):
         # if no type is passed, then this is the starting point
         if current_type is None:
             current_type = self.configuration.root_model
-        current_type.model_rebuild(force=True)
+        current_type.model_rebuild()
         if isinstance(path, str):
             path = Path(path)
         if not current_object_paths:


### PR DESCRIPTION
improving loader time by: 
1. not setting "force=True" on model rebuild. This setting prevented pydantics caching, I suppose
2. using cache signature to prevent walking the directory too often