### PR TITLE
Allow frame names to be unique and fix fowarder references

### DIFF
--- a/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/can_interfaces/diag_can_interface.flync.yaml
+++ b/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/can_interfaces/diag_can_interface.flync.yaml
@@ -1,6 +1,9 @@
 bus_ref: DiagCAN
 sender_frames:
-  - frame_ref: Frame_EngineDiagResponse
-  - frame_ref: Frame_NmMessage
+  - bus_ref: DiagCAN
+    frame_ref: 2024  # Frame_EngineDiagResponse (0x7E8)
+  - bus_ref: DiagCAN
+    frame_ref: 1280  # Frame_NmMessage (0x500)
 receiver_frames:
-  - frame_ref: Frame_LightDiagRequest
+  - bus_ref: DiagCAN
+    frame_ref: 2015  # Frame_LightDiagRequest (0x7DF)

--- a/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/can_interfaces/powertrain_can_interface.flync.yaml
+++ b/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/can_interfaces/powertrain_can_interface.flync.yaml
@@ -1,9 +1,12 @@
 bus_ref: PowertrainCAN
 sender_frames: []
 receiver_frames:
-  - frame_ref: Frame_EngineStatus
-  - frame_ref: Frame_VehicleDynamics
-  - frame_ref: Frame_TransmissionStatus
+  - bus_ref: PowertrainCAN
+    frame_ref: 257   # Frame_EngineStatus (0x101)
+  - bus_ref: PowertrainCAN
+    frame_ref: 513   # Frame_VehicleDynamics (0x201)
+  - bus_ref: PowertrainCAN
+    frame_ref: 769   # Frame_TransmissionStatus (0x301)
 
 forwarder_frames:
   - frame_ref: Frame_EngineStatus

--- a/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/can_interfaces/powertrain_can_interface.flync.yaml
+++ b/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/can_interfaces/powertrain_can_interface.flync.yaml
@@ -10,6 +10,6 @@ forwarder_frames:
     egresses:
       - egress_type: can_frame
         bus_ref: DiagCAN
-        frame_ref: Frame_EngineDiagResponse
+        frame_ref: 2024  # Frame_EngineDiagResponse (0x7E8)
       - egress_type: eth_socket
         socket_ref: pdu_engine_status_tx

--- a/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/ethernet_interfaces/hpc_c1_iface1/sockets/socket_pdu.flync.yaml
+++ b/examples/flync_example/ecus/high_performance_compute/controllers/hpc_controller1/ethernet_interfaces/hpc_c1_iface1/sockets/socket_pdu.flync.yaml
@@ -30,7 +30,7 @@ sockets:
         egresses:
           - egress_type: can_frame
             bus_ref: DiagCAN
-            frame_ref: Frame_EngineDiagResponse
+            frame_ref: 2024  # Frame_EngineDiagResponse (0x7E8)
             extract_pdu_ref: PDU_EngineStatus
 
           - egress_type: eth_socket

--- a/examples/flync_example/ecus/zonal_platform1/controllers/z1_controller1/lin_interfaces/body_lin_interface.flync.yaml
+++ b/examples/flync_example/ecus/zonal_platform1/controllers/z1_controller1/lin_interfaces/body_lin_interface.flync.yaml
@@ -4,6 +4,9 @@ lin_protocol: "2.2A"
 p2_min: 0.5
 st_min: 0.0
 sender_frames:
-  - frame_ref: Frame_MirrorLeftStatus
-  - frame_ref: Frame_MirrorRightStatus
-  - frame_ref: Frame_CabinLightStatus
+  - bus_ref: BodyLIN
+    frame_ref: 1   # Frame_MirrorLeftStatus
+  - bus_ref: BodyLIN
+    frame_ref: 2   # Frame_MirrorRightStatus
+  - bus_ref: BodyLIN
+    frame_ref: 5   # Frame_CabinLightStatus

--- a/src/flync/core/utils/forwarder_validators.py
+++ b/src/flync/core/utils/forwarder_validators.py
@@ -401,7 +401,7 @@ def _check_can_frame_egress(
             ctrl=forwarder_controller.name,
         )
     egress_frame = can_frame_by_bus_id.get((egress.bus_ref, egress.frame_ref))
-    if egress_frame is None or not any(s.frame_ref == egress_frame.name for s in iface.sender_frames):
+    if egress_frame is None or not any(s.bus_ref == egress.bus_ref and s.frame_ref == egress.frame_ref for s in iface.sender_frames):
         raise err_major(
             "{owner}: can_frame egress targets frame id={frame} on bus '{bus}', "
             "but controller '{ctrl}' does not list it in sender_frames of that interface.",

--- a/src/flync/core/utils/forwarder_validators.py
+++ b/src/flync/core/utils/forwarder_validators.py
@@ -136,19 +136,22 @@ def _build_socket_indexes(model: "FLYNCModel"):
     return socket_by_controller_name, pdu_forwarder_by_controller_socket_pdu
 
 
-def _build_can_indexes(model: "FLYNCModel"):
-    """Build indexes for CAN interface lookup ``(controller, bus)`` and CAN forwarder lookup ``(bus, frame)``."""
+def _build_can_indexes(model: "FLYNCModel", can_frame_catalogue: Optional[Dict[str, CANAnyFrame]] = None):
+    """Build indexes for CAN interface lookup ``(controller, bus)`` and CAN forwarder lookup ``(bus, can_id)``."""
 
     can_iface_by_controller_bus: Dict[Tuple[str, str], CANInterfaceConfig] = {}
-    can_forwarder_by_bus_frame: Dict[Tuple[str, str], CANFrameForwarder] = {}
+    can_forwarder_by_bus_id: Dict[Tuple[str, int], CANFrameForwarder] = {}
 
     for ecu in model.ecus:
         for controller in ecu.controllers:
             for can_iface in controller.can_interfaces or []:
                 can_iface_by_controller_bus[(controller.name, can_iface.bus_ref)] = can_iface
-                for fwd in can_iface.forwarder_frames or []:
-                    can_forwarder_by_bus_frame[(can_iface.bus_ref, fwd.frame_ref)] = fwd
-    return can_iface_by_controller_bus, can_forwarder_by_bus_frame
+                if can_frame_catalogue is not None:
+                    for fwd in can_iface.forwarder_frames or []:
+                        frame = can_frame_catalogue.get(fwd.frame_ref)
+                        if frame is not None:
+                            can_forwarder_by_bus_id[(can_iface.bus_ref, frame.can_id)] = fwd
+    return can_iface_by_controller_bus, can_forwarder_by_bus_id
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +183,19 @@ def _build_can_frame_catalogue(model: "FLYNCModel") -> Dict[str, CANAnyFrame]:
     for bus in channels.can_buses:
         for frame in bus.frames or []:
             out[frame.name] = frame
+    return out
+
+
+def _build_can_frame_catalogue_by_bus_id(model: "FLYNCModel") -> Dict[Tuple[str, int], CANAnyFrame]:
+    """Return a ``(bus_name, can_id)``-keyed dict of every CAN / CAN FD frame, for egress lookups by CAN ID."""
+
+    out: Dict[Tuple[str, int], CANAnyFrame] = {}
+    channels = getattr(model.communication, "channels", None) if model.communication else None
+    if channels is None or channels.can_buses is None:
+        return out
+    for bus in channels.can_buses:
+        for frame in bus.frames or []:
+            out[(bus.name, frame.can_id)] = frame
     return out
 
 
@@ -234,7 +250,7 @@ def _resolve_egress_pdu(
 def _validate_pdu_forwarder_refs_for(
     fwd: PDUForwarder,
     pdu_catalogue: Dict[str, PDU],
-    can_frame_catalogue: Dict[str, CANAnyFrame],
+    can_frame_by_bus_id: Dict[Tuple[str, int], CANAnyFrame],
 ) -> None:
     """Resolve and payload-check one ``PDUForwarder`` against the workspace PDU / CAN-frame catalogues."""
 
@@ -246,13 +262,14 @@ def _validate_pdu_forwarder_refs_for(
             owner=owner,
             ref=fwd.pdu_ref,
         )
-    _resolve_sinks_for(fwd.egresses, ingress_pdu, pdu_catalogue, can_frame_catalogue, owner)
+    _resolve_sinks_for(fwd.egresses, ingress_pdu, pdu_catalogue, can_frame_by_bus_id, owner)
 
 
 def _validate_can_frame_forwarder_refs_for(
     fwd: CANFrameForwarder,
     pdu_catalogue: Dict[str, PDU],
     can_frame_catalogue: Dict[str, CANAnyFrame],
+    can_frame_by_bus_id: Dict[Tuple[str, int], CANAnyFrame],
 ) -> None:
     """Resolve and payload-check one ``CANFrameForwarder`` (ingress PDU is the single packed PDU of its ingress frame)."""
 
@@ -267,14 +284,14 @@ def _validate_can_frame_forwarder_refs_for(
     ingress_pdu: Optional[PDU] = None
     if ingress_frame.packed_pdus and len(ingress_frame.packed_pdus) == 1:
         ingress_pdu = pdu_catalogue.get(ingress_frame.packed_pdus[0].pdu_ref)
-    _resolve_sinks_for(fwd.egresses, ingress_pdu, pdu_catalogue, can_frame_catalogue, owner)
+    _resolve_sinks_for(fwd.egresses, ingress_pdu, pdu_catalogue, can_frame_by_bus_id, owner)
 
 
 def _resolve_sinks_for(
     egresses,
     ingress_pdu: Optional[PDU],
     pdu_catalogue: Dict[str, PDU],
-    can_frame_catalogue: Dict[str, CANAnyFrame],
+    can_frame_by_bus_id: Dict[Tuple[str, int], CANAnyFrame],
     owner: str,
 ) -> None:
     """Per-egress resolution + payload-fit (CAN egresses only)."""
@@ -284,13 +301,14 @@ def _resolve_sinks_for(
         egress_label = f"egresses[{idx}]"
         egress_pdu = _resolve_egress_pdu(ingress_pdu, egress.extract_pdu_ref, pdu_catalogue, egress_label, owner)
         if isinstance(egress, CANFrameEgress):
-            egress_frame = can_frame_catalogue.get(egress.frame_ref)
+            egress_frame = can_frame_by_bus_id.get((egress.bus_ref, egress.frame_ref))
             if egress_frame is None:
                 raise err_major(
-                    "{owner}: {egress}: frame_ref '{ref}' does not name any CAN or CAN FD frame.",
+                    "{owner}: {egress}: frame_ref id={ref} on bus '{bus}' does not name any CAN or CAN FD frame.",
                     owner=owner,
                     egress=egress_label,
                     ref=egress.frame_ref,
+                    bus=egress.bus_ref,
                 )
             if egress_pdu is not None and egress_pdu.length > egress_frame.length:
                 raise err_minor(
@@ -309,16 +327,17 @@ def validate_forwarder_refs(model: "FLYNCModel") -> None:
 
     pdu_catalogue = _build_pdu_catalogue(model)
     can_frame_catalogue = _build_can_frame_catalogue(model)
+    can_frame_by_bus_id = _build_can_frame_catalogue_by_bus_id(model)
 
     for ctrl, socket, fwd in _collect_pdu_forwarders(model):
         try:
-            _validate_pdu_forwarder_refs_for(fwd, pdu_catalogue, can_frame_catalogue)
+            _validate_pdu_forwarder_refs_for(fwd, pdu_catalogue, can_frame_by_bus_id)
         except PydanticCustomError as err:
             raise _with_source(err, _pdu_forwarder_locator(ctrl, socket, fwd)) from None
 
     for ctrl, iface, fwd in _collect_can_frame_forwarders(model):
         try:
-            _validate_can_frame_forwarder_refs_for(fwd, pdu_catalogue, can_frame_catalogue)
+            _validate_can_frame_forwarder_refs_for(fwd, pdu_catalogue, can_frame_catalogue, can_frame_by_bus_id)
         except PydanticCustomError as err:
             raise _with_source(err, _can_forwarder_locator(ctrl, iface, fwd)) from None
 
@@ -369,6 +388,7 @@ def _check_can_frame_egress(
     owner: str,
     forwarder_controller: "Controller",
     can_iface_by_controller_bus: Dict[Tuple[str, str], CANInterfaceConfig],
+    can_frame_by_bus_id: Dict[Tuple[str, int], CANAnyFrame],
 ) -> None:
     """Assert a ``can_frame`` egress targets a CAN interface on the forwarder's controller that is set up to send the egress frame."""
 
@@ -380,9 +400,10 @@ def _check_can_frame_egress(
             bus=egress.bus_ref,
             ctrl=forwarder_controller.name,
         )
-    if not any(s.frame_ref == egress.frame_ref for s in iface.sender_frames):
+    egress_frame = can_frame_by_bus_id.get((egress.bus_ref, egress.frame_ref))
+    if egress_frame is None or not any(s.frame_ref == egress_frame.name for s in iface.sender_frames):
         raise err_major(
-            "{owner}: can_frame egress targets frame '{frame}' on bus '{bus}', "
+            "{owner}: can_frame egress targets frame id={frame} on bus '{bus}', "
             "but controller '{ctrl}' does not list it in sender_frames of that interface.",
             owner=owner,
             frame=egress.frame_ref,
@@ -398,6 +419,7 @@ def _check_forwarder_egress_locality(
     controller: "Controller",
     socket_by_controller_name: Dict[Tuple[str, str], Tuple["Controller", "Socket"]],
     can_iface_by_controller_bus: Dict[Tuple[str, str], CANInterfaceConfig],
+    can_frame_by_bus_id: Dict[Tuple[str, int], CANAnyFrame],
 ) -> None:
     """Dispatch a single egress to its locality check; raise on an unresolvable eth_socket egress PDU."""
 
@@ -409,7 +431,7 @@ def _check_forwarder_egress_locality(
             )
         _check_eth_socket_egress(egress, egress_owner, egress_pdu_ref, controller, socket_by_controller_name)
     else:
-        _check_can_frame_egress(egress, egress_owner, controller, can_iface_by_controller_bus)
+        _check_can_frame_egress(egress, egress_owner, controller, can_iface_by_controller_bus, can_frame_by_bus_id)
 
 
 def _validate_pdu_forwarder_locality(
@@ -418,6 +440,7 @@ def _validate_pdu_forwarder_locality(
     fwd: PDUForwarder,
     socket_by_controller_name: Dict[Tuple[str, str], Tuple["Controller", "Socket"]],
     can_iface_by_controller_bus: Dict[Tuple[str, str], CANInterfaceConfig],
+    can_frame_by_bus_id: Dict[Tuple[str, int], CANAnyFrame],
 ) -> None:
     """Locality + direction safety for every egress of one ``PDUForwarder``."""
 
@@ -432,6 +455,7 @@ def _validate_pdu_forwarder_locality(
             controller,
             socket_by_controller_name,
             can_iface_by_controller_bus,
+            can_frame_by_bus_id,
         )
 
 
@@ -442,6 +466,7 @@ def _validate_can_frame_forwarder_locality(
     socket_by_controller_name: Dict[Tuple[str, str], Tuple["Controller", "Socket"]],
     can_iface_by_controller_bus: Dict[Tuple[str, str], CANInterfaceConfig],
     can_frame_catalogue: Dict[str, CANAnyFrame],
+    can_frame_by_bus_id: Dict[Tuple[str, int], CANAnyFrame],
 ) -> None:
     """Locality + direction safety for every egress of one ``CANFrameForwarder``."""
 
@@ -457,6 +482,7 @@ def _validate_can_frame_forwarder_locality(
             controller,
             socket_by_controller_name,
             can_iface_by_controller_bus,
+            can_frame_by_bus_id,
         )
 
 
@@ -466,10 +492,11 @@ def validate_forwarder_locality(model: "FLYNCModel") -> None:
     socket_by_controller_name, _ = _build_socket_indexes(model)
     can_iface_by_controller_bus, _ = _build_can_indexes(model)
     can_frame_catalogue = _build_can_frame_catalogue(model)
+    can_frame_by_bus_id = _build_can_frame_catalogue_by_bus_id(model)
 
     for controller, socket, fwd in _collect_pdu_forwarders(model):
         try:
-            _validate_pdu_forwarder_locality(controller, socket, fwd, socket_by_controller_name, can_iface_by_controller_bus)
+            _validate_pdu_forwarder_locality(controller, socket, fwd, socket_by_controller_name, can_iface_by_controller_bus, can_frame_by_bus_id)
         except PydanticCustomError as err:
             raise _with_source(err, _pdu_forwarder_locator(controller, socket, fwd)) from None
 
@@ -482,6 +509,7 @@ def validate_forwarder_locality(model: "FLYNCModel") -> None:
                 socket_by_controller_name,
                 can_iface_by_controller_bus,
                 can_frame_catalogue,
+                can_frame_by_bus_id,
             )
         except PydanticCustomError as err:
             raise _with_source(err, _can_forwarder_locator(controller, parent_iface, fwd)) from None
@@ -514,8 +542,8 @@ class _ForwarderCycleDetector(object):
 
     def __init__(self, model: "FLYNCModel") -> None:
         _, self._pdu_forwarder_idx = _build_socket_indexes(model)
-        _, self._can_forwarder_idx = _build_can_indexes(model)
         self._can_frame_catalogue = _build_can_frame_catalogue(model)
+        _, self._can_forwarder_idx = _build_can_indexes(model, self._can_frame_catalogue)
 
         pdu_fwds = _collect_pdu_forwarders(model)
         can_fwds = _collect_can_frame_forwarders(model)

--- a/src/flync/model/flync_4_bus/can_bus.py
+++ b/src/flync/model/flync_4_bus/can_bus.py
@@ -106,17 +106,6 @@ class CANBus(UniqueName):
         return self
 
     @model_validator(mode="after")
-    def validate_unique_frame_names(self) -> "CANBus":
-        duplicates = sorted(n for n, c in Counter(f.name for f in self.frames).items() if c > 1)
-        if duplicates:
-            raise err_minor(
-                "CANBus '{name}' has duplicate frame name(s): {duplicates}",
-                name=self.name,
-                duplicates=duplicates,
-            )
-        return self
-
-    @model_validator(mode="after")
     def validate_unique_can_ids(self) -> "CANBus":
         keys = [(f.can_id, f.id_format) for f in self.frames]
         duplicates = sorted(f"{cid:#x}/{fmt}" for (cid, fmt), c in Counter(keys).items() if c > 1)

--- a/src/flync/model/flync_4_ecu/can_interface.py
+++ b/src/flync/model/flync_4_ecu/can_interface.py
@@ -12,16 +12,19 @@ from flync.model.flync_4_signal.forwarder import CANFrameForwarder
 
 class CANFrameRef(FLYNCBaseModel):
     """
-    Reference to a CAN frame by name.
+    Reference to a CAN frame by bus and CAN ID.
 
     Parameters
     ----------
-    frame_ref : str
-        Name of the :class:`~flync.model.flync_4_signal.frame.CANFrame` or
-        :class:`~flync.model.flync_4_signal.frame.CANFDFrame` defined in the referenced CAN bus.
+    bus_ref : str
+        Name of the :class:`~flync.model.flync_4_bus.can_bus.CANBus` that owns the frame.
+    frame_ref : int
+        CAN ID of the :class:`~flync.model.flync_4_signal.frame.CANFrame` or
+        :class:`~flync.model.flync_4_signal.frame.CANFDFrame` on the referenced bus.
     """
 
-    frame_ref: str = Field()
+    bus_ref: str = Field()
+    frame_ref: int = Field()
 
 
 class CANInterfaceConfig(FLYNCBaseModel):

--- a/src/flync/model/flync_4_ecu/lin_interface.py
+++ b/src/flync/model/flync_4_ecu/lin_interface.py
@@ -12,15 +12,18 @@ _LINProtocol = Literal["1.3", "2.0", "2.1", "2.2A"]
 
 class LINFrameRef(FLYNCBaseModel):
     """
-    Reference to a LIN frame by name.
+    Reference to a LIN frame by bus and LIN ID.
 
     Parameters
     ----------
-    frame_ref : str
-        Name of the :class:`~flync.model.flync_4_signal.frame.LINFrame` defined in the referenced LIN bus.
+    bus_ref : str
+        Name of the :class:`~flync.model.flync_4_bus.lin_bus.LINBus` that owns the frame.
+    frame_ref : int
+        LIN ID of the :class:`~flync.model.flync_4_signal.frame.LINFrame` on the referenced bus.
     """
 
-    frame_ref: str = Field()
+    bus_ref: str = Field()
+    frame_ref: int = Field()
 
 
 class LINMasterInterfaceConfig(FLYNCBaseModel):

--- a/src/flync/model/flync_4_signal/forwarder.py
+++ b/src/flync/model/flync_4_signal/forwarder.py
@@ -13,7 +13,7 @@ class CANFrameEgress(FLYNCBaseModel):
 
     egress_type: Literal["can_frame"] = Field(default="can_frame")
     bus_ref: str = Field()
-    frame_ref: str = Field()
+    frame_ref: int = Field()
     extract_pdu_ref: Optional[str] = Field(default=None)
 
 

--- a/src/flync/model/flync_4_signal/frame.py
+++ b/src/flync/model/flync_4_signal/frame.py
@@ -2,7 +2,7 @@ from typing import Annotated, FrozenSet, List, Literal, Optional
 
 from pydantic import Field, model_validator
 
-from flync.core.base_models import FLYNCBaseModel, UniqueName
+from flync.core.base_models import FLYNCBaseModel
 from flync.core.utils.exceptions import err_minor
 from flync.model.flync_4_signal.pdu import (
     PDUInstance,

--- a/src/flync/model/flync_4_signal/frame.py
+++ b/src/flync/model/flync_4_signal/frame.py
@@ -109,7 +109,7 @@ class FrameTransmissionTiming(FLYNCBaseModel):
 # ---------------------------------------------------------------------------
 
 
-class Frame(UniqueName):
+class Frame(FLYNCBaseModel):
     """
     Protocol-agnostic frame base class.
 

--- a/src/flync_converter/converters/dbc_converter.py
+++ b/src/flync_converter/converters/dbc_converter.py
@@ -166,15 +166,15 @@ def decode_pdu(  # NOSONAR
 
 def _collect_frame_participants(flync_model: FLYNCModel):
     """Return (frame_senders, frame_receivers) dicts built from all ECU CAN interfaces."""
-    frame_senders: dict[str, list] = {}
-    frame_receivers: dict[str, list] = {}
+    frame_senders: dict[tuple, list] = {}
+    frame_receivers: dict[tuple, list] = {}
     for ecu in flync_model.ecus:
         for ctrl in ecu.controllers:
             for iface in ctrl.can_interfaces or []:
                 for f in iface.sender_frames:
-                    frame_senders.setdefault(f.frame_ref, []).append(ecu.name)
+                    frame_senders.setdefault((f.bus_ref, f.frame_ref), []).append(ecu.name)
                 for f in iface.receiver_frames:
-                    frame_receivers.setdefault(f.frame_ref, []).append(ecu.name)
+                    frame_receivers.setdefault((f.bus_ref, f.frame_ref), []).append(ecu.name)
     return frame_senders, frame_receivers
 
 
@@ -189,7 +189,7 @@ def _build_can_messages(flync_model: FLYNCModel, can_bus, pdus: dict, frame_send
                 flync_model,
                 pdu_obj,  # type: ignore[arg-type]
                 pdu_inst.bit_position or 0,
-                frame_receivers.get(frame.name, None),
+                frame_receivers.get((can_bus.name, frame.can_id), None),
             )
         messages.append(
             Message(
@@ -198,7 +198,7 @@ def _build_can_messages(flync_model: FLYNCModel, can_bus, pdus: dict, frame_send
                 length=frame.length,
                 signals=sigs,
                 comment=frame.description,
-                senders=frame_senders.get(frame.name, None),
+                senders=frame_senders.get((can_bus.name, frame.can_id), None),
                 is_extended_frame=frame.id_format == "extended_29bit",
                 is_fd=frame.type == "can_fd",
             )

--- a/tests/converter_tests/test_dbc_converter.py
+++ b/tests/converter_tests/test_dbc_converter.py
@@ -233,9 +233,11 @@ class TestCollectFrameParticipants:
 
     def test_single_ecu(self):
         sf = MagicMock()
-        sf.frame_ref = "FX"
+        sf.frame_ref = 0x100
+        sf.bus_ref = "BUS_A"
         rf = MagicMock()
-        rf.frame_ref = "FY"
+        rf.frame_ref = 0x200
+        rf.bus_ref = "BUS_A"
         iface = MagicMock()
         iface.sender_frames = [sf]
         iface.receiver_frames = [rf]
@@ -247,8 +249,8 @@ class TestCollectFrameParticipants:
         model = MagicMock()
         model.ecus = [ecu]
         senders, receivers = _collect_frame_participants(model)
-        assert senders == {"FX": ["ECU_A"]}
-        assert receivers == {"FY": ["ECU_A"]}
+        assert senders == {("BUS_A", 0x100): ["ECU_A"]}
+        assert receivers == {("BUS_A", 0x200): ["ECU_A"]}
 
     def test_no_can_interfaces(self):
         ctrl = MagicMock()
@@ -262,9 +264,10 @@ class TestCollectFrameParticipants:
         assert senders == {} and receivers == {}
 
     def test_multiple_ecus_same_frame(self):
-        def _ecu(name, frame_ref):
+        def _ecu(name, frame_ref, bus_ref="BUS_X"):
             sf = MagicMock()
             sf.frame_ref = frame_ref
+            sf.bus_ref = bus_ref
             iface = MagicMock()
             iface.sender_frames = [sf]
             iface.receiver_frames = []
@@ -276,9 +279,9 @@ class TestCollectFrameParticipants:
             return e
 
         model = MagicMock()
-        model.ecus = [_ecu("E1", "F1"), _ecu("E2", "F1")]
+        model.ecus = [_ecu("E1", 0x100), _ecu("E2", 0x100)]
         senders, _ = _collect_frame_participants(model)
-        assert senders == {"F1": ["E1", "E2"]}
+        assert senders == {("BUS_X", 0x100): ["E1", "E2"]}
 
 
 class TestBuildCanMessages:

--- a/tests/system_test/model/test_forwarders.py
+++ b/tests/system_test/model/test_forwarders.py
@@ -42,7 +42,7 @@ def test_canonical_scenario_1_can_to_can_egress_present(loaded_canonical_workspa
 
     fwd = loaded_canonical_workspace.flync_model.get_all_can_frame_forwarders()[0]
     can_sinks = [s.root for s in fwd.egresses if isinstance(s.root, CANFrameEgress)]
-    assert any(s.bus_ref == "DiagCAN" and s.frame_ref == "Frame_EngineDiagResponse" for s in can_sinks)
+    assert any(s.bus_ref == "DiagCAN" and s.frame_ref == 2024 for s in can_sinks)
 
 
 def test_canonical_scenario_2_can_to_eth_sink_present(loaded_canonical_workspace):
@@ -68,7 +68,7 @@ def test_canonical_scenario_3_eth_to_can_with_extraction(loaded_canonical_worksp
 
     fwd = loaded_canonical_workspace.flync_model.get_all_pdu_forwarders()[0]
     can_sinks = [s.root for s in fwd.egresses if isinstance(s.root, CANFrameEgress)]
-    assert any(s.bus_ref == "DiagCAN" and s.frame_ref == "Frame_EngineDiagResponse" and s.extract_pdu_ref == "PDU_EngineStatus" for s in can_sinks)
+    assert any(s.bus_ref == "DiagCAN" and s.frame_ref == 2024 and s.extract_pdu_ref == "PDU_EngineStatus" for s in can_sinks)
 
 
 def test_canonical_scenario_4_eth_to_eth_rebridge(loaded_canonical_workspace):
@@ -157,7 +157,7 @@ def test_negative_can_egress_not_in_sender_frames(workspace_copy):
     _mutate_file(_diag_ifc(workspace_copy), {"- frame_ref: Frame_EngineDiagResponse\n": ""})
     _assert_message_contains(
         _load_or_capture(workspace_copy),
-        ["Frame_EngineDiagResponse", "sender_frames"],
+        ["2024", "sender_frames"],
     )
 
 
@@ -193,15 +193,15 @@ def test_negative_eth_socket_egress_target_has_no_pdu_sender(workspace_copy):
 
 
 def test_negative_unknown_pdu_ref(workspace_copy):
-    """A CANFrameForwarder targeting an unknown frame triggers err_major."""
+    """A CANFrameEgress targeting an unknown CAN ID triggers err_major."""
 
     _mutate_file(
         _pwrtr_ifc(workspace_copy),
-        {"frame_ref: Frame_EngineDiagResponse": "frame_ref: Frame_DoesNotExist"},
+        {"frame_ref: 2024  # Frame_EngineDiagResponse (0x7E8)": "frame_ref: 9999"},
     )
     _assert_message_contains(
         _load_or_capture(workspace_copy),
-        ["Frame_DoesNotExist"],
+        ["9999"],
     )
 
 
@@ -264,7 +264,7 @@ def test_negative_two_bus_cycle(workspace_copy):
     _mutate_file(
         _diag_ifc(workspace_copy),
         {
-            "receiver_frames:\n  - frame_ref: Frame_LightDiagRequest": "receiver_frames:\n  - frame_ref: Frame_LightDiagRequest\nforwarder_frames:\n  - frame_ref: Frame_EngineDiagResponse\n    egresses:\n      - egress_type: can_frame\n        bus_ref: PowertrainCAN\n        frame_ref: Frame_EngineStatus",
+            "receiver_frames:\n  - frame_ref: Frame_LightDiagRequest": "receiver_frames:\n  - frame_ref: Frame_LightDiagRequest\nforwarder_frames:\n  - frame_ref: Frame_EngineDiagResponse\n    egresses:\n      - egress_type: can_frame\n        bus_ref: PowertrainCAN\n        frame_ref: 257",
         },
     )
     _assert_message_contains(
@@ -304,7 +304,7 @@ def test_positive_scenario_3_eth_container_extracted_to_can(workspace_copy):
     _mutate_file(
         _hpc_eth_socket_pdu(workspace_copy),
         {
-            "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer": "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer\n      - deployment_type: pdu_forwarder\n        pdu_ref: EthPowertrainContainer\n        egresses:\n          - egress_type: can_frame\n            bus_ref: DiagCAN\n            frame_ref: Frame_EngineDiagResponse\n            extract_pdu_ref: PDU_EngineStatus",
+            "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer": "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer\n      - deployment_type: pdu_forwarder\n        pdu_ref: EthPowertrainContainer\n        egresses:\n          - egress_type: can_frame\n            bus_ref: DiagCAN\n            frame_ref: 2024\n            extract_pdu_ref: PDU_EngineStatus",
         },
     )
     ws = FLYNCWorkspace.load_workspace("flync_example", workspace_copy)
@@ -323,7 +323,7 @@ def test_negative_extract_pdu_ref_not_in_container(workspace_copy):
     _mutate_file(
         _hpc_eth_socket_pdu(workspace_copy),
         {
-            "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer": "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer\n      - deployment_type: pdu_forwarder\n        pdu_ref: EthPowertrainContainer\n        egresses:\n          - egress_type: can_frame\n            bus_ref: DiagCAN\n            frame_ref: Frame_EngineDiagResponse\n            extract_pdu_ref: PDU_DoesNotExist",
+            "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer": "  - name: pdu_powertrain_tx\n    endpoint_address: 10.0.20.5\n    endpoint_type: unicast\n    port_no: 30800\n    protocol: udp\n    deployments:\n      - deployment_type: pdu_sender\n        pdu_ref: EthPowertrainContainer\n      - deployment_type: pdu_forwarder\n        pdu_ref: EthPowertrainContainer\n        egresses:\n          - egress_type: can_frame\n            bus_ref: DiagCAN\n            frame_ref: 2024\n            extract_pdu_ref: PDU_DoesNotExist",
         },
     )
     _assert_message_contains(

--- a/tests/system_test/model/test_forwarders.py
+++ b/tests/system_test/model/test_forwarders.py
@@ -154,7 +154,7 @@ def _hpc_eth_socket_pdu(ws: Path) -> Path:
 def test_negative_can_egress_not_in_sender_frames(workspace_copy):
     """Drop Frame_EngineDiagResponse from DiagCAN sender_frames -> locality check fires."""
 
-    _mutate_file(_diag_ifc(workspace_copy), {"- frame_ref: Frame_EngineDiagResponse\n": ""})
+    _mutate_file(_diag_ifc(workspace_copy), {"  - bus_ref: DiagCAN\n    frame_ref: 2024  # Frame_EngineDiagResponse (0x7E8)\n": ""})
     _assert_message_contains(
         _load_or_capture(workspace_copy),
         ["2024", "sender_frames"],
@@ -259,12 +259,12 @@ def test_negative_two_bus_cycle(workspace_copy):
 
     _mutate_file(
         _pwrtr_ifc(workspace_copy),
-        {"sender_frames: []": "sender_frames:\n  - frame_ref: Frame_EngineStatus"},
+        {"sender_frames: []": "sender_frames:\n  - bus_ref: PowertrainCAN\n    frame_ref: 257"},
     )
     _mutate_file(
         _diag_ifc(workspace_copy),
         {
-            "receiver_frames:\n  - frame_ref: Frame_LightDiagRequest": "receiver_frames:\n  - frame_ref: Frame_LightDiagRequest\nforwarder_frames:\n  - frame_ref: Frame_EngineDiagResponse\n    egresses:\n      - egress_type: can_frame\n        bus_ref: PowertrainCAN\n        frame_ref: 257",
+            "receiver_frames:\n  - bus_ref: DiagCAN\n    frame_ref: 2015  # Frame_LightDiagRequest (0x7DF)": "receiver_frames:\n  - bus_ref: DiagCAN\n    frame_ref: 2015  # Frame_LightDiagRequest (0x7DF)\nforwarder_frames:\n  - frame_ref: Frame_EngineDiagResponse\n    egresses:\n      - egress_type: can_frame\n        bus_ref: PowertrainCAN\n        frame_ref: 257",
         },
     )
     _assert_message_contains(

--- a/tests/system_test/model/test_signal_negative.py
+++ b/tests/system_test/model/test_signal_negative.py
@@ -112,7 +112,7 @@ def test_invalid_lin_frame_in_can_interface():
                 compatible_flync_version=BaseVersion(version_schema="semver", version="0.11.0"),
                 target_system="my_system",
             ),
-            can_interfaces=[CANInterfaceConfig(bus_ref="CAN0", receiver_frames=[CANFrameRef(frame_ref=lin_frame.name)])],
+            can_interfaces=[CANInterfaceConfig(bus_ref="CAN0", receiver_frames=[CANFrameRef(bus_ref="CAN0", frame_ref=lin_frame.lin_id)])],
         )
 
 
@@ -140,7 +140,7 @@ def test_invalid_can_frame_in_lin_interface():
                     lin_protocol="2.0A",
                     p2_min=0.001,
                     st_min=0.001,
-                    sender_frames=[CANFrameRef(frame_ref=can_frame.name)],  # invalid
+                    sender_frames=[CANFrameRef(bus_ref="LIN0", frame_ref=can_frame.can_id)],  # invalid
                 )
             ],
             can_interfaces=[],

--- a/tests/unit_test/model/tests_4_signal/test_pdu_forwarder.py
+++ b/tests/unit_test/model/tests_4_signal/test_pdu_forwarder.py
@@ -14,7 +14,7 @@ from flync.model.flync_4_signal.forwarder import (
 )
 
 
-def _can_egress(bus_ref: str, frame_ref: str, extract_pdu_ref: str | None = None) -> ForwarderEgress:
+def _can_egress(bus_ref: str, frame_ref: int, extract_pdu_ref: str | None = None) -> ForwarderEgress:
     return ForwarderEgress(root=CANFrameEgress(bus_ref=bus_ref, frame_ref=frame_ref, extract_pdu_ref=extract_pdu_ref))
 
 
@@ -47,7 +47,7 @@ def test_positive_pdu_forwarder_constructs_without_registry():
 
     fwd = PDUForwarder(
         pdu_ref="PDU_Anything",
-        egresses=[_can_egress(bus_ref="DiagCAN", frame_ref="Frame_X")],
+        egresses=[_can_egress(bus_ref="DiagCAN", frame_ref=0x100)],
     )
     assert fwd.pdu_ref == "PDU_Anything"
     assert len(fwd.egresses) == 1
@@ -60,7 +60,7 @@ def test_negative_extra_field_rejected_on_pdu_forwarder():
 
 def test_negative_extra_field_rejected_on_can_frame_sink():
     with pytest.raises(ValidationError):
-        CANFrameEgress.model_validate({"bus_ref": "B", "frame_ref": "F", "unknown_field": 1})
+        CANFrameEgress.model_validate({"bus_ref": "B", "frame_ref": 1, "unknown_field": 1})
 
 
 def test_negative_extra_field_rejected_on_eth_eth_socket_egress():
@@ -94,8 +94,8 @@ def test_negative_pdu_forwarder_duplicate_can_egresss():
         PDUForwarder(
             pdu_ref="PDU_X",
             egresses=[
-                _can_egress(bus_ref="DiagCAN", frame_ref="Frame_X"),
-                _can_egress(bus_ref="DiagCAN", frame_ref="Frame_X"),
+                _can_egress(bus_ref="DiagCAN", frame_ref=0x200),
+                _can_egress(bus_ref="DiagCAN", frame_ref=0x200),
             ],
         )
     assert "duplicates" in str(exc.value).lower()
@@ -117,8 +117,8 @@ def test_positive_pdu_forwarder_different_egress_targets_ok():
     fwd = PDUForwarder(
         pdu_ref="PDU_X",
         egresses=[
-            _can_egress(bus_ref="A", frame_ref="F"),
-            _can_egress(bus_ref="B", frame_ref="F"),
+            _can_egress(bus_ref="A", frame_ref=0x100),
+            _can_egress(bus_ref="B", frame_ref=0x100),
             _eth_socket_egress(socket_ref="sock_a"),
         ],
     )
@@ -140,16 +140,16 @@ def test_negative_can_frame_forwarder_duplicate_sinks():
         CANFrameForwarder(
             frame_ref="Frame_X",
             egresses=[
-                _can_egress(bus_ref="DiagCAN", frame_ref="F1"),
-                _can_egress(bus_ref="DiagCAN", frame_ref="F1"),
+                _can_egress(bus_ref="DiagCAN", frame_ref=0x101),
+                _can_egress(bus_ref="DiagCAN", frame_ref=0x101),
             ],
         )
     assert "duplicates" in str(exc.value).lower()
 
 
 def test_negative_can_interface_duplicate_forwarder_frames():
-    fwd_a = CANFrameForwarder(frame_ref="Frame_X", egresses=[_can_egress(bus_ref="DiagCAN", frame_ref="F1")])
-    fwd_b = CANFrameForwarder(frame_ref="Frame_X", egresses=[_can_egress(bus_ref="DiagCAN", frame_ref="F2")])
+    fwd_a = CANFrameForwarder(frame_ref="Frame_X", egresses=[_can_egress(bus_ref="DiagCAN", frame_ref=0x101)])
+    fwd_b = CANFrameForwarder(frame_ref="Frame_X", egresses=[_can_egress(bus_ref="DiagCAN", frame_ref=0x102)])
     with pytest.raises(ValidationError) as exc:
         CANInterfaceConfig(name="can0", bus_ref="PowertrainCAN", forwarder_frames=[fwd_a, fwd_b])
     assert "duplicate" in str(exc.value).lower()
@@ -158,7 +158,7 @@ def test_negative_can_interface_duplicate_forwarder_frames():
 def test_positive_can_interface_receiver_and_forwarder_coexist():
     """A frame can legitimately appear in receiver_frames AND forwarder_frames (dual-consume)."""
 
-    fwd = CANFrameForwarder(frame_ref="Frame_X", egresses=[_can_egress(bus_ref="DiagCAN", frame_ref="F1")])
+    fwd = CANFrameForwarder(frame_ref="Frame_X", egresses=[_can_egress(bus_ref="DiagCAN", frame_ref=0x101)])
     iface = CANInterfaceConfig(
         name="can0",
         bus_ref="PowertrainCAN",

--- a/tests/unit_test/model/tests_4_signal/test_pdu_forwarder.py
+++ b/tests/unit_test/model/tests_4_signal/test_pdu_forwarder.py
@@ -162,10 +162,10 @@ def test_positive_can_interface_receiver_and_forwarder_coexist():
     iface = CANInterfaceConfig(
         name="can0",
         bus_ref="PowertrainCAN",
-        receiver_frames=[CANFrameRef(frame_ref="Frame_X")],
+        receiver_frames=[CANFrameRef(bus_ref="PowertrainCAN", frame_ref=0x101)],
         forwarder_frames=[fwd],
     )
-    assert iface.receiver_frames[0].frame_ref == "Frame_X"
+    assert iface.receiver_frames[0].frame_ref == 0x101
     assert iface.forwarder_frames[0].frame_ref == "Frame_X"
 
 


### PR DESCRIPTION
Changes:
 
Allowed Frames to have non unique names
Updated forwarder reference in CAN egresser in CAN interface and sockets to reference CAN Frames by id.
Updated the validators for forwarder references
Added frame_ref and bus ref to CAN interface and Lin interface sender and receiver frames because referencing just by frame name wont suffice now.
Update the validators and test such as to uniquely reference each frame by the combination of bus name and unique CAN ID per bus