### PR TITLE
ci: separated unittest and performance tests into different jobs

### DIFF
--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -99,12 +99,10 @@ jobs:
           path: type-check-reports
           retention-days: 28
 
-  pytest:
+  performance-tests:
+    continue-on-error: true
     runs-on: ubuntu-latest
     needs: [format-check, lint, type-check, isort]
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -119,10 +117,89 @@ jobs:
           pip install "poetry>=2.0.0,<3.0.0" "poetry-dynamic-versioning>=1.0.0,<2.0.0"
           poetry install --with test
 
-      - name: Run Pytest
+      - name: Run Performance tests
+        run: |
+          COVERAGE_FILE=.coverage.performance poetry run pytest -m performance --cov=flync --cov-report= --junitxml=report_performance.xml --durations=0
+
+      - name: Upload performance tests artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: performance-coverage
+          path: |
+            .coverage.performance
+            report_performance.xml
+          retention-days: 28
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: [format-check, lint, type-check, isort]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: |
+          sudo apt update && sudo apt install -y libglib2.0-0 libgl1 libegl1 libdbus-1-3 libfontconfig1 libxcb1 libxkbcommon0
+
+      - name: Prepare
+        run: |
+          pip install --upgrade pip
+          pip install "poetry>=2.0.0,<3.0.0" "poetry-dynamic-versioning>=1.0.0,<2.0.0"
+          poetry install --with test
+
+      - name: Run Unittest
         run: |
           COVERAGE_FILE=.coverage.unit poetry run pytest -m "not performance" --cov=flync --cov-report= --junitxml=report_not_performance.xml --durations=0
-          COVERAGE_FILE=.coverage.performance poetry run pytest -m performance --cov=flync --cov-report= --junitxml=report_performance.xml --durations=0
+
+      - name: Upload unittest artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: unittest-coverage
+          path: |
+            .coverage.unit
+            report_not_performance.xml
+          retention-days: 28
+
+  tests-summary:
+    runs-on: ubuntu-latest
+    needs: [performance-tests, unit-tests]
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download performance tests artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: performance-coverage
+          path: |
+            .coverage.performance
+            report_performance.xml
+        continue-on-error: true
+
+      - name: Download unittest artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: unittest-coverage
+          path: |
+            .coverage.unit
+            report_not_performance.xml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt update && sudo apt install -y libglib2.0-0 libgl1 libegl1 libdbus-1-3 libfontconfig1 libxcb1 libxkbcommon0
+
+      - name: Prepare
+        run: |
+          pip install --upgrade pip
+          pip install "poetry>=2.0.0,<3.0.0" "poetry-dynamic-versioning>=1.0.0,<2.0.0"
+          poetry install --with test
+
+      - name: Generate reports
+        run: |
           poetry run coverage combine .coverage.unit .coverage.performance
           poetry run coverage xml
           poetry run coverage report

--- a/.github/workflows/push_and_pr.yaml
+++ b/.github/workflows/push_and_pr.yaml
@@ -129,6 +129,8 @@ jobs:
           path: |
             .coverage.performance
             report_performance.xml
+          include-hidden-files: true
+          if-no-files-found: warn
           retention-days: 28
 
   unit-tests:
@@ -153,12 +155,15 @@ jobs:
           COVERAGE_FILE=.coverage.unit poetry run pytest -m "not performance" --cov=flync --cov-report= --junitxml=report_not_performance.xml --durations=0
 
       - name: Upload unittest artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: unittest-coverage
           path: |
             .coverage.unit
             report_not_performance.xml
+          include-hidden-files: true
+          if-no-files-found: error
           retention-days: 28
 
   tests-summary:
@@ -171,22 +176,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Download performance tests artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: performance-coverage
-          path: |
-            .coverage.performance
-            report_performance.xml
-        continue-on-error: true
-
       - name: Download unittest artifacts
         uses: actions/download-artifact@v7
         with:
           name: unittest-coverage
-          path: |
-            .coverage.unit
-            report_not_performance.xml
+          path: .
+
+      - name: Download performance tests artifacts
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          name: performance-coverage
+          path: .
 
       - name: Install system dependencies
         run: |
@@ -232,6 +233,7 @@ jobs:
             report_performance.xml
             tests/unit_test/sdk/fuzzed
             tests/unit_test/sdk/generated
+          include-hidden-files: true
           retention-days: 28
 
   example-validation:


### PR DESCRIPTION
## Description

Split unittest and performance tests into separate jobs and configure tests-summary job to combine coverage and XML reports for both test categories.

## Changes Made

- .github/workflows/push_and_pull.yaml

## Testing Instructions (if applicable)

<!-- Provide clear testing instructions of your changes for reviewers. -->

1. Execute pipeline with changes from this PR
2. Observe the result
3. Deliberately make performance tests job fail
4. Observe the result

## Checklist

- [x] My code follows the project's style guidelines.
- [ ] All new and existing tests pass.
- [ ] I have verified these changes **both** locally on my development environment as well as in production/CI environments and checked that there are no errors (if applicable).
- [ ] This pull request is ready for review.
